### PR TITLE
feat(types): implement TypeScript type definitions

### DIFF
--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -1,0 +1,99 @@
+import type { Job, JobStatus } from "./job";
+
+export interface HuntOptions {
+  profileId?: string;      // defaults to defaultProfileId
+  role?: string;           // overrides profile.targetRoles
+  location?: string;       // overrides profile.targetLocations
+  companyIds?: string[];   // restrict to specific companies
+  providers?: string[];    // override enabled providers
+  maxResults?: number;     // override config.hunt.maxResults
+}
+
+export interface HuntResult {
+  jobs: Job[];
+  newCount: number;        // jobs not previously seen
+  avgScore: number;
+}
+
+export interface TailorOptions {
+  jobId: string;
+  profileId?: string;      // defaults to defaultProfileId
+  resume?: string;         // path to .tex; defaults to profile.resumePath
+  coverLetter?: boolean;   // default true
+  diff?: boolean;          // show before/after comparison
+}
+
+export interface TailorResult {
+  tailoredTexPath: string | null;    // null if resume was not re-tailored
+  tailoredPdfPath: string | null;
+  coverLetterMdPath: string | null;
+  coverLetterPdfPath: string | null;
+  changes: string[];
+  matchScore: number;
+}
+
+export interface FormField {
+  name: string;
+  type: string;            // "text", "email", "file", "select", "checkbox", etc.
+  required: boolean;
+  value: string | null;    // null if no mapping found from profile
+}
+
+export interface FillOptions {
+  jobId: string;
+  profileId?: string;          // defaults to defaultProfileId
+  dryRun?: boolean;            // default true — preview only, don't submit
+  resumePath?: string;         // defaults to tailored resume for this job
+  coverLetterPath?: string;    // defaults to tailored CL for this job
+}
+
+export interface FillResult {
+  fields: FormField[];
+  submitted: boolean;
+  screenshotPath: string | null;
+}
+
+export interface Contact {
+  name: string;
+  title: string;               // e.g. "Engineering Manager"
+  companyId: string | null;    // null if company not in database
+  companyName: string;         // always present for display even if companyId is null
+  email: string | null;
+  emailInferred: boolean;      // true if guessed from pattern (e.g. first.last@company.com)
+  linkedinUrl: string | null;
+}
+
+export interface ReachOptions {
+  jobId: string;
+  profileId?: string;   // defaults to defaultProfileId; determines sender name/email
+  send?: boolean;       // default false — draft only
+}
+
+export interface ReachResult {
+  contacts: Contact[];
+  draftPath: string;
+  sent: boolean;
+}
+
+export interface StatusOptions {
+  status?: JobStatus;
+  companyIds?: string[];
+  minScore?: number;
+  since?: string;       // ISO 8601
+}
+
+export interface StatusResult {
+  jobs: Job[];
+  total: number;
+  byStatus: Record<JobStatus, number>;
+}
+
+/**
+ * Plugin interface (strategy pattern) for job sources.
+ * Each provider independently implements this interface.
+ * wolf hunt iterates all enabled providers, merges and deduplicates results, then scores.
+ */
+export interface JobProvider {
+  name: string;
+  hunt(options: HuntOptions): Promise<Job[]>;
+}

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,0 +1,40 @@
+/**
+ * Numeric company size tier — designed to be comparable.
+ * 1 = startup (<50), 2 = small (50–500), 3 = mid (500–5000), 4 = bigtech (5000+)
+ */
+export type CompanySize = 1 | 2 | 3 | 4;
+
+/**
+ * A company is a first-class entity stored separately from jobs.
+ * Multiple jobs from the same company share one Company record.
+ * The domain field is used by the reach command to infer email patterns.
+ */
+export interface Company {
+  id: string;                          // uuid
+  name: string;                        // e.g. "TikTok", "Google"
+  domain: string | null;               // e.g. "tiktok.com"
+  linkedinUrl: string | null;
+  size: CompanySize | null;
+  industry: string | null;             // e.g. "Software", "Finance"
+  headquartersLocation: string | null; // e.g. "Mountain View, CA"
+  notes: string | null;                // user's personal notes
+  createdAt: string;                   // ISO 8601
+  updatedAt: string;                   // ISO 8601
+}
+
+export interface CompanyQuery {
+  size?: CompanySize | CompanySize[];
+  industry?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CompanyUpdate {
+  name?: string;
+  domain?: string | null;
+  linkedinUrl?: string | null;
+  size?: CompanySize | null;
+  industry?: string | null;
+  headquartersLocation?: string | null;
+  notes?: string | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+export * from "./company";
+export * from "./job";
+export * from "./resume";
+export * from "./profile";
+export * from "./commands";

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,0 +1,76 @@
+import type { CompanySize } from "./company";
+
+/** Where a job sits in the user's personal pipeline. */
+export type JobStatus =
+  | "new"        // just found by wolf, not yet reviewed
+  | "reviewed"   // user has seen it, not dismissed — next step is to apply
+  | "ignored"    // user manually dismissed; kept for recovery
+  | "filtered"   // auto-dismissed by dealbreaker rules; kept for recovery
+  | "applied"    // application submitted
+  | "interview"  // company reached out for interview
+  | "offer"      // received an offer
+  | "rejected";  // company passed, or user withdrew
+
+/**
+ * Annual compensation in USD, or "unpaid" for internships/volunteer roles.
+ * Using a union type forces explicit handling of the unpaid case.
+ */
+export type Salary = number | "unpaid";
+
+/** Where wolf found the job. */
+export type JobSource = "linkedin" | "handshake" | "email" | "browser_mcp" | "manual";
+
+/**
+ * One job listing — the central data object stored in SQLite.
+ * Every wolf command reads from or writes to Job records.
+ */
+export interface Job {
+  id: string;                              // uuid
+  title: string;                           // e.g. "Software Engineer Intern"
+  companyId: string;                       // foreign key → Company.id
+  url: string;                             // application or listing URL
+  source: JobSource;
+  description: string;                     // full JD text
+  location: string;                        // specific office location for this role
+  remote: boolean;
+  salary: Salary | null;                   // null if not listed
+  workAuthorizationRequired: string | null; // e.g. "no sponsorship", "US citizens only"
+  score: number | null;                    // AI relevance score 0.0–1.0; null if unscored
+  scoreJustification: string | null;
+  status: JobStatus;
+  appliedProfileId: string | null;         // which profile was used; null if not yet applied
+  tailoredResumePath: string | null;
+  tailoredResumePdfPath: string | null;
+  coverLetterPath: string | null;
+  coverLetterPdfPath: string | null;
+  screenshotPath: string | null;
+  outreachDraftPath: string | null;
+  createdAt: string;                       // ISO 8601
+  updatedAt: string;                       // ISO 8601
+}
+
+export interface JobQuery {
+  status?: JobStatus | JobStatus[];
+  companyIds?: string[];
+  minScore?: number;
+  since?: string;          // ISO 8601
+  source?: JobSource;
+  limit?: number;
+  offset?: number;
+}
+
+export interface JobUpdate {
+  status?: JobStatus;
+  appliedProfileId?: string | null;
+  score?: number | null;
+  scoreJustification?: string | null;
+  tailoredResumePath?: string | null;
+  tailoredResumePdfPath?: string | null;
+  coverLetterPath?: string | null;
+  coverLetterPdfPath?: string | null;
+  screenshotPath?: string | null;
+  outreachDraftPath?: string | null;
+}
+
+// Re-export CompanySize so callers that need it alongside Job don't need a second import
+export type { CompanySize };

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,102 @@
+import type { CompanySize } from "./company";
+
+/**
+ * Per-profile scoring configuration.
+ *
+ * Scoring is a hybrid model:
+ * - AI scores roleMatch (semantic understanding of JD vs. target roles/skills)
+ * - Algorithm scores everything else (workAuth, location, remote, salary, companySize)
+ * - weights are the algorithm's coefficients; AI never sees them
+ *
+ * Dealbreakers run before scoring — a job that trips one is immediately
+ * set to "filtered" and never scored, saving AI API calls.
+ */
+export interface ScoringPreferences {
+  /** Anchors that the algorithm measures deviation from. */
+  preferences: {
+    minSalary: number | null;            // minimum acceptable annual salary in USD
+    preferredCompanySizes: CompanySize[]; // e.g. [3, 4] = mid or bigtech; [] = no preference
+  };
+
+  /** Weight of each factor in the final score (0.0–1.0; ideally sum to 1.0). */
+  weights: {
+    workAuth: number;    // auth match vs. profile immigrationStatus
+    roleMatch: number;   // AI's semantic role relevance score
+    location: number;    // location match vs. profile targetLocations
+    remote: number;      // remote preference match
+    salary: number;      // salary vs. preferences.minSalary
+    companySize: number; // company size proximity to preferences.preferredCompanySizes
+  };
+
+  /**
+   * Hard filters — evaluated before scoring.
+   * true  = must have this property
+   * false = must NOT have this property
+   * null  = no filter
+   */
+  dealbreakers: {
+    /** true = must offer sponsorship; false = must NOT sponsor; null = don't care */
+    sponsorship: boolean | null;
+    /** true = must be remote; false = must be on-site; null = don't care */
+    remote: boolean | null;
+  };
+}
+
+/**
+ * A complete identity used when applying.
+ * Wolf supports multiple profiles to handle ATS workarounds, different
+ * immigration statuses, or name variants.
+ *
+ * Multiple profiles can share the same base .tex resume — wolf always
+ * injects this profile's contact info into the resume header at generation time.
+ */
+export interface UserProfile {
+  id: string;                      // e.g. "default", "gc-persona"
+  label: string;                   // human-readable, e.g. "Default", "Green Card"
+  name: string;
+  alternateName: string[];         // other names used on applications
+  email: string;
+  alternateEmail: string[];
+  phone: string;                   // required — most forms demand a phone number
+  alternatePhone: string[];
+  linkedinUrl: string | null;
+  githubUrl: string | null;
+  websiteUrl: string | null;
+  immigrationStatus: string;       // required — affects scoring; e.g. "F-1 OPT", "US citizen"
+  currentCity: string | null;
+  willingToRelocate: boolean;
+  workAuthTimeline: string | null; // e.g. "OPT starts May 2026"
+  targetRoles: string[];           // e.g. ["Software Engineer", "Full Stack Developer"]
+  targetLocations: string[];       // e.g. ["NYC", "SF", "Remote"]
+  skills: string[];
+  resumePath: string;              // path to base .tex; contact header is injected from this profile
+  targetedCompanyIds: string[];    // companies actively watched; jobs from these get a scoring boost
+  scoringPreferences: ScoringPreferences;
+}
+
+export interface ProviderConfig {
+  enabled: boolean;
+  strategy?: string; // provider-specific, e.g. "email" for handshake
+}
+
+/**
+ * Top-level config loaded from ~/.wolf/config.json on startup.
+ * default* fields are baselines — individual command runs can override them via options.
+ */
+export interface AppConfig {
+  profiles: UserProfile[];          // at least one required
+  defaultProfileId: string;
+  providers: Record<string, ProviderConfig>;
+  hunt: {
+    minScore: number;               // default 0.5
+    maxResults: number;             // default 50
+  };
+  tailor: {
+    defaultTemplatePath: string | null;
+    defaultCoverLetterTone: string; // e.g. "professional", "conversational"
+  };
+  reach: {
+    defaultEmailTone: string;       // e.g. "professional", "casual"
+    maxEmailsPerDay: number;        // safety limit, default 10
+  };
+}

--- a/src/types/resume.ts
+++ b/src/types/resume.ts
@@ -1,0 +1,37 @@
+/** Free-form section (e.g. Summary, Objective) — no structured bullet items. */
+export interface ResumePlainSection {
+  heading: string;
+  content: string;
+}
+
+export interface ResumeSectionItem {
+  title: string | null;       // null for unnamed items
+  subtitle: string | null;    // e.g. company name
+  location: string | null;    // e.g. "Mountain View, CA"
+  date: string | null;        // e.g. "Jun 2025 – Aug 2025"
+  bullets: string[];
+}
+
+/** Structured section with bullet-point items (e.g. Experience, Education). */
+export interface ResumeSection {
+  heading: string;
+  items: ResumeSectionItem[];
+}
+
+/**
+ * Parsed, structured form of a .tex resume file.
+ * The contact info header is treated as placeholder content —
+ * wolf always overwrites it with the selected UserProfile's data at generation time.
+ */
+export interface Resume {
+  name: string;
+  contactInfo: {
+    email: string;
+    phone: string | null;
+    linkedin: string | null;
+    github: string | null;
+    website: string | null;
+  };
+  sections: (ResumeSection | ResumePlainSection)[];
+  rawTex: string; // original .tex source
+}


### PR DESCRIPTION
## Summary
- Translates all types from `docs/TYPES.md` into `src/types/`
- Splits into domain files: `company.ts`, `job.ts`, `resume.ts`, `profile.ts`, `commands.ts`
- `index.ts` becomes a thin re-export so external imports are unchanged

## Test plan
- [ ] Verify `src/types/index.ts` re-exports all types correctly
- [ ] Confirm no circular imports between domain files