### PR TITLE
Add portfolioPath and transcriptPath to UserProfile type

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -134,3 +134,10 @@ Decisions made during Milestone 1 are reconstructed retrospectively from commit 
 **Me:** After `wolf add`, the AI should be able to immediately score the job and present results to the user — not wait for an async batch.
 **AI:** Batch API exists for cost savings on bulk jobs. For a single user-initiated job, synchronous Haiku is the right call: seconds instead of minutes/hours, and the marginal cost difference is negligible for one job.
 **Result:** Adopted. `ScoreOptions.single: true` skips the Batch API and calls Haiku synchronously. Default remains batch for bulk scoring.
+
+---
+
+**2026-03-25 — Added `portfolioPath` and `transcriptPath` to `UserProfile`; read-only, PDF only**
+**Me:** Portfolio and transcript should be tracked per-profile like `resumePath`, but wolf should never modify them.
+**AI:** Both fields follow the same per-profile pattern as `resumePath` (stored in `UserProfile`, configurable in `wolf init`). Key constraints enforced by convention and validated at init time: (1) read-only — wolf may attach or reference these files but must never write to them; (2) PDF only — no `.tex` or other formats accepted.
+**Result:** Adopted. `portfolioPath: string | null` and `transcriptPath: string | null` added to `UserProfile`. `wolf init` prompts for both (skippable, validated for `.pdf` extension). Unlike `resumePath`, these fields have no tailoring pipeline and will never gain one.

--- a/docs/DECISIONS_zh.md
+++ b/docs/DECISIONS_zh.md
@@ -134,3 +134,10 @@ Milestone 1 期间的决策根据 commit 历史和对话记录进行了追溯整
 **我：** `wolf add` 之后，AI 应该能立即对该职位评分并将结果呈现给用户，而不是等待异步 batch。
 **AI：** Batch API 的存在是为了批量评分省钱。对于用户主动触发的单条职位，同步调用 Haiku 才是正确选择：几秒钟而非几分钟/几小时，且单条评分的绝对费用差异可以忽略不计。
 **结果：** 采用。`ScoreOptions.single: true` 跳过 Batch API，同步调用 Haiku。批量评分默认仍走 batch。
+
+---
+
+**2026-03-25 — 在 `UserProfile` 中新增 `portfolioPath` 和 `transcriptPath`；只读，仅支持 PDF**
+**我：** Portfolio 和 transcript 应像 `resumePath` 一样按 profile 独立配置，但 wolf 永远不应修改这些文件。
+**AI：** 两个字段沿用与 `resumePath` 相同的 per-profile 模式（存储在 `UserProfile`，通过 `wolf init` 配置）。两条约束在规范层面强制执行，并在 init 时校验：(1) 只读——wolf 可以附加或引用这些文件，但绝不允许写入；(2) 仅支持 PDF——不接受 `.tex` 或其他格式。
+**结果：** 采用。`portfolioPath: string | null` 和 `transcriptPath: string | null` 添加至 `UserProfile`。`wolf init` 新增提示（可跳过，校验 `.pdf` 后缀）。与 `resumePath` 不同，这两个字段没有定制化处理流程，也永远不会有。

--- a/docs/TYPES.md
+++ b/docs/TYPES.md
@@ -210,6 +210,8 @@ interface UserProfile {
   targetLocations: string[];        // e.g. ["NYC", "SF", "Remote"]
   skills: string[];                 // e.g. ["TypeScript", "React", "Python"]
   resumePath: string;               // path to base resume .tex file (contact header is injected from this profile)
+  portfolioPath: string | null;     // path to portfolio PDF; wolf reads only, never modifies; must be .pdf
+  transcriptPath: string | null;    // path to transcript PDF; wolf reads only, never modifies; must be .pdf
   targetedCompanyIds: string[];     // companies the user is actively watching; jobs from these companies get a scoring boost
   scoringPreferences: ScoringPreferences;
 }

--- a/docs/TYPES_zh.md
+++ b/docs/TYPES_zh.md
@@ -213,6 +213,8 @@ interface UserProfile {
   targetLocations: string[];        // 例如 ["NYC", "SF", "Remote"]
   skills: string[];                 // 例如 ["TypeScript", "React", "Python"]
   resumePath: string;               // base 简历 .tex 文件路径（联系方式 header 由本 profile 注入）
+  portfolioPath: string | null;     // portfolio PDF 路径；wolf 只读，永不修改；必须是 .pdf 文件
+  transcriptPath: string | null;    // 成绩单 PDF 路径；wolf 只读，永不修改；必须是 .pdf 文件
   targetedCompanyIds: string[];     // 用户主动盯着的公司列表；这些公司的职位在评分时获得加分
   scoringPreferences: ScoringPreferences;
 }

--- a/src/commands/init/__tests__/init.test.ts
+++ b/src/commands/init/__tests__/init.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseDocumentPath } from '../index.js';
+
+describe('parseDocumentPath', () => {
+  describe('blank input → null', () => {
+    it('returns null for empty string', () => {
+      expect(parseDocumentPath('', ['pdf'])).toBeNull();
+    });
+
+    it('returns null for whitespace-only string', () => {
+      expect(parseDocumentPath('   ', ['pdf'])).toBeNull();
+    });
+  });
+
+  describe('valid extensions → trimmed path', () => {
+    it('accepts .pdf when pdf is allowed', () => {
+      expect(parseDocumentPath('portfolio.pdf', ['pdf'])).toBe('portfolio.pdf');
+    });
+
+    it('accepts .tex when tex is allowed', () => {
+      expect(parseDocumentPath('resume.tex', ['pdf', 'tex'])).toBe('resume.tex');
+    });
+
+    it('accepts .pdf when both pdf and tex are allowed', () => {
+      expect(parseDocumentPath('resume.pdf', ['pdf', 'tex'])).toBe('resume.pdf');
+    });
+
+    it('trims surrounding whitespace from the returned path', () => {
+      expect(parseDocumentPath('  portfolio.pdf  ', ['pdf'])).toBe('portfolio.pdf');
+    });
+  });
+
+  describe('invalid path shape → throws', () => {
+    it('throws for a filename with no extension', () => {
+      expect(() => parseDocumentPath('portfolio', ['pdf'])).toThrow();
+    });
+
+    it('throws for a dot-only extension like .pdf with no filename', () => {
+      expect(() => parseDocumentPath('.pdf', ['pdf'])).toThrow();
+    });
+  });
+
+  describe('invalid extension → throws', () => {
+    it('throws for .docx when only pdf is allowed', () => {
+      expect(() => parseDocumentPath('file.docx', ['pdf'])).toThrow();
+    });
+
+    it('throws for .md when pdf and tex are allowed', () => {
+      expect(() => parseDocumentPath('resume.md', ['pdf', 'tex'])).toThrow();
+    });
+
+    it('error message includes the offending filename', () => {
+      expect(() => parseDocumentPath('wrong.docx', ['pdf'])).toThrow('wrong.docx');
+    });
+
+    it('error message lists the allowed extensions', () => {
+      expect(() => parseDocumentPath('wrong.docx', ['pdf', 'tex'])).toThrow('.pdf');
+    });
+  });
+});

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -6,6 +6,35 @@ import { backupConfig, saveConfig } from '../../utils/config.js';
 import { envSet } from '../env/index.js';
 import type { AppConfig } from '../../types/index.js';
 
+/**
+ * Parses and validates a user-supplied document path.
+ *
+ * @param raw - Raw string from user input (may be empty or whitespace).
+ *   e.g. `'  resume.pdf  '` → trimmed to `'resume.pdf'`
+ *   e.g. `''` or `'   '` → returns null
+ * @param allowed - Permitted file extensions without leading dot, e.g. ['pdf'] or ['pdf', 'tex'].
+ * @returns Trimmed path, or null if the input was blank.
+ * @throws If the path has no filename (e.g. `'.pdf'`), no extension (e.g. `'resume'`),
+ *   or an extension not in the allowed list (e.g. `'resume.md'` when only pdf/tex allowed).
+ */
+export function parseDocumentPath(raw: string, allowed: string[]): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const dotIndex = trimmed.lastIndexOf('.');
+  if (dotIndex <= 0) {
+    throw new Error(
+      `File must be ${allowed.map(e => `.${e}`).join(' or ')} (got: ${trimmed})`
+    );
+  }
+  const ext = trimmed.slice(dotIndex + 1).toLowerCase();
+  if (!allowed.includes(ext)) {
+    throw new Error(
+      `File must be ${allowed.map(e => `.${e}`).join(' or ')} (got: ${trimmed})`
+    );
+  }
+  return trimmed;
+}
+
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
@@ -151,6 +180,24 @@ Please place your resume file inside resume/:
     });
   }
 
+  // ── Step 1b: Optional PDF documents (portfolio, transcript) ──────────────
+  console.log(`
+${bold('── Optional Documents (PDF only) ──')}
+${dim('These files are attached as-is — wolf will never modify them.')}
+`);
+
+  const portfolioRaw = await input({
+    message: 'Portfolio PDF path (leave blank to skip):',
+    default: '',
+  });
+  const portfolioPath = parseDocumentPath(portfolioRaw, ['pdf']);
+
+  const transcriptRaw = await input({
+    message: 'Transcript PDF path (leave blank to skip):',
+    default: '',
+  });
+  const transcriptPath = parseDocumentPath(transcriptRaw, ['pdf']);
+
   // ── Step 2: Basic profile info ────────────────────────────────────────────
   console.log(`\n${bold('── Profile ──')}`);
 
@@ -212,6 +259,8 @@ Please place your resume file inside resume/:
         targetLocations,
         skills: [],
         resumePath,
+        portfolioPath,
+        transcriptPath,
         targetedCompanyIds: [],
         scoringPreferences: {
           preferences: { minSalary: null, preferredCompanySizes: [] },

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -70,6 +70,10 @@ export interface UserProfile {
   targetLocations: string[];       // e.g. ["NYC", "SF", "Remote"]
   skills: string[];
   resumePath: string;              // path to base .tex; contact header is injected from this profile
+  /** Path to portfolio PDF. Wolf reads this file only — never modifies it. Must be .pdf. */
+  portfolioPath: string | null;
+  /** Path to transcript PDF. Wolf reads this file only — never modifies it. Must be .pdf. */
+  transcriptPath: string | null;
   targetedCompanyIds: string[];    // companies actively watched; jobs from these get a scoring boost
   scoringPreferences: ScoringPreferences;
 }


### PR DESCRIPTION
- Add portfolioPath and transcriptPath (string | null) to UserProfile type
- Both fields are read-only (wolf attaches, never modifies) and PDF-only
- wolf init prompts for both paths optionally; blank input → null
- Extract parseDocumentPath(raw, allowed) helper with extension and filename validation; replaces inline IIFE logic
- Add 12 unit tests covering blank, valid, invalid extension, and invalid path shape (no filename, dot-only) cases
- Sync TYPES.md, TYPES_zh.md, DECISIONS.md, DECISIONS_zh.md