### PR TITLE
feat(db): SQLite layer and wolf add command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "better-sqlite3": "^11.9.1",
         "commander": "^13.1.0",
         "dotenv": "^16.4.7",
+        "drizzle-kit": "^0.31.10",
+        "drizzle-orm": "^0.45.1",
         "openai": "^6.32.0",
         "smol-toml": "^1.6.0"
       },
@@ -57,6 +59,12 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
@@ -89,6 +97,833 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -789,7 +1624,7 @@
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1137,6 +1972,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1385,6 +2226,603 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/drizzle-kit/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
+      "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1473,6 +2911,47 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/escape-html": {
@@ -1767,7 +3246,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1822,6 +3300,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -2774,6 +4264,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
@@ -3070,6 +4569,15 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3078,6 +4586,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -3237,6 +4755,25 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "better-sqlite3": "^11.9.1",
     "commander": "^13.1.0",
     "dotenv": "^16.4.7",
+    "drizzle-kit": "^0.31.10",
+    "drizzle-orm": "^0.45.1",
     "openai": "^6.32.0",
     "smol-toml": "^1.6.0"
   },

--- a/src/commands/add/__tests__/add.test.ts
+++ b/src/commands/add/__tests__/add.test.ts
@@ -1,16 +1,73 @@
 /**
  * Tests for commands/add/index.ts
- *
- * TDD: implement add.ts, then convert it.todo → it and fill in assertions.
  */
 
-import { describe, it } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type * as DbModule from '../../../utils/db.js';
+
+// Intercept initDb so add() uses :memory: instead of needing wolf.toml on disk.
+// All other db functions (upsertCompany, saveJob, getJob, getCompany) remain real.
+vi.mock('../../../utils/db.js', async () => {
+  const actual = await vi.importActual<typeof DbModule>('../../../utils/db.js');
+  return {
+    ...actual,
+    initDb: async () => actual.initDb(':memory:'),
+  };
+});
+
+// Import after mock is registered
+const { add } = await import('../index.js');
+const { initDb, getJob, getCompany } = await import('../../../utils/db.js');
+
+beforeEach(async () => {
+  await initDb(':memory:');
+});
+
+const baseOptions = () => ({
+  title: 'Software Engineer',
+  company: 'Acme Corp',
+  jdText: 'Full JD text here.',
+  location: 'New York, NY',
+  remote: false,
+});
 
 describe('add', () => {
-  it.todo('saves the job to DB and returns a jobId');
-  it.todo('saves the job with status raw and score null');
-  it.todo('uses source "manual" to identify AI-submitted jobs');
-  it.todo('stores the url when provided');
-  it.todo('uses empty string for url when not provided');
-  it.todo('upserts the company and sets companyId on the job');
+  it('saves the job to DB and returns a jobId', async () => {
+    const result = await add(baseOptions());
+    expect(typeof result.jobId).toBe('string');
+    expect(result.jobId.length).toBeGreaterThan(0);
+  });
+
+  it('saves the job with status new and score null', async () => {
+    const { jobId } = await add(baseOptions());
+    const job = await getJob(jobId);
+    expect(job?.status).toBe('new');
+    expect(job?.score).toBeNull();
+  });
+
+  it('uses source "manual" to identify AI-submitted jobs', async () => {
+    const { jobId } = await add(baseOptions());
+    const job = await getJob(jobId);
+    expect(job?.source).toBe('manual');
+  });
+
+  it('stores the url when provided', async () => {
+    const { jobId } = await add({ ...baseOptions(), url: 'https://example.com/job/1' });
+    const job = await getJob(jobId);
+    expect(job?.url).toBe('https://example.com/job/1');
+  });
+
+  it('uses empty string for url when not provided', async () => {
+    const { jobId } = await add(baseOptions());
+    const job = await getJob(jobId);
+    expect(job?.url).toBe('');
+  });
+
+  it('upserts the company and sets companyId on the job', async () => {
+    const { jobId } = await add(baseOptions());
+    const job = await getJob(jobId);
+    expect(typeof job?.companyId).toBe('string');
+    const company = await getCompany(job!.companyId);
+    expect(company?.name).toBe('Acme Corp');
+  });
 });

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -9,9 +9,9 @@
  * ## Typical AI-orchestrated flow
  *
  *   User: "I found this job, looks interesting" + shares content
- *   AI: extracts { title, company, jdText, url? }
- *   AI: calls wolf_add({ title, company, jdText, url })
- *     → wolf saves job with status: 'raw', score: null
+ *   AI: extracts { title, company, jdText, url?, location, remote, salary?, workAuthorizationRequired? }
+ *   AI: calls wolf_add({ title, company, jdText, url, location, remote })
+ *     → wolf saves job with status: 'new', score: null
  *     → returns { jobId }
  *   AI: calls wolf_score({ jobIds: [jobId], single: true })
  *     → synchronous Haiku scoring, returns score + comment
@@ -24,6 +24,7 @@
  */
 
 import type { AddOptions, AddResult } from '../../types/index.js';
+import { initDb, upsertCompany, saveJob } from '../../utils/db.js';
 
 /**
  * Saves a single AI-structured job to the local database.
@@ -32,17 +33,50 @@ import type { AddOptions, AddResult } from '../../types/index.js';
  *   - title: job title
  *   - company: company name (used to upsert a Company record)
  *   - jdText: full job description text
+ *   - location: work location extracted from JD (e.g. "San Francisco, CA")
+ *   - remote: whether the role is remote, extracted from JD
  *   - url: original job posting URL (optional; defaults to empty string if not provided)
+ *   - salary: compensation extracted from JD (optional)
+ *   - workAuthorizationRequired: sponsorship info extracted from JD (optional)
  *   - profileId: reserved for future use
  * @returns jobId — the DB-assigned id for chaining into wolf_score or wolf_tailor.
  * @throws If the DB cannot be initialized (e.g. wolf.toml not found in cwd).
  */
-export async function add(_options: AddOptions): Promise<AddResult> {
-  // TODO(M2):
-  // 1. Initialize DB (initDb from utils/db)
-  // 2. Upsert company by name (upsertCompany) to get a companyId FK
-  // 3. Save job with status 'raw', score null, source 'manual'
-  //    Unknown fields (location, remote, salary) stay null — wolf score fills them in
-  // 4. Return { jobId }
-  throw new Error('Not implemented');
+export async function add(options: AddOptions): Promise<AddResult> {
+  // Ensure DB is ready (throws if not, e.g. missing wolf.toml)
+  await initDb(process.cwd());
+
+  const companyId = await upsertCompany({
+    name: options.company,
+    domain: null,
+    linkedinUrl: null,
+    size: null,
+    industry: null,
+    headquartersLocation: null,
+    notes: null,
+  });
+
+  const jobId = await saveJob({
+    title: options.title,
+    companyId,
+    url: options.url ?? '',
+    source: options.source ?? 'manual',
+    description: options.jdText,
+    location: options.location,
+    remote: options.remote,
+    salary: options.salary ?? null,
+    workAuthorizationRequired: options.workAuthorizationRequired ?? null,
+    score: null,
+    scoreJustification: null,
+    status: 'new',
+    appliedProfileId: null,
+    tailoredResumePath: null,
+    tailoredResumePdfPath: null,
+    coverLetterPath: null,
+    coverLetterPdfPath: null,
+    screenshotPath: null,
+    outreachDraftPath: null,
+  });
+
+  return { jobId };
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -18,8 +18,13 @@ export interface AddOptions {
   title: string;
   company: string;
   jdText: string;
-  url?: string;         // original job posting URL, if available
-  profileId?: string;   // defaults to defaultProfileId
+  location: string;                              // extracted from JD by AI caller
+  remote: boolean;                               // extracted from JD by AI caller
+  url?: string;                                  // original job posting URL, if available
+  salary?: number | 'unpaid';                    // extracted from JD by AI caller, if present
+  workAuthorizationRequired?: string;            // extracted from JD by AI caller, if present
+  source?: string;                               // defaults to 'manual'; use 'browser' for extension, etc.
+  profileId?: string;                            // defaults to defaultProfileId
 }
 
 export interface AddResult {

--- a/src/utils/__tests__/db.test.ts
+++ b/src/utils/__tests__/db.test.ts
@@ -1,57 +1,238 @@
 /**
  * Tests for utils/db.ts
  *
- * Uses a temporary SQLite file per test run so tests are fully isolated.
- * No mocking needed — we test against a real (temp file) DB.
- *
- * TDD: implement db.ts, then convert it.todo → it and fill in assertions.
+ * Each test gets a fresh in-memory SQLite database via initDb(':memory:').
+ * No mocking needed — we test against a real DB.
  */
 
-import { describe, it } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  initDb, upsertCompany, getCompany,
+  saveJob, saveJobs, getJob, getJobs, updateJob,
+  countByStatus, saveBatch, getPendingBatches, updateBatchStatus,
+} from '../db.js';
+import type { Job } from '../../types/index.js';
+
+// Reset the module-level db singleton before each test via a fresh initDb call.
+// Using a unique temp path per test suite run (in-memory doesn't persist between calls).
+beforeEach(async () => {
+  // Re-initialise with :memory: — each call creates a fresh in-memory database.
+  await initDb(':memory:');
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseJob = (): Omit<Job, 'id' | 'createdAt' | 'updatedAt'> => ({
+  title: 'Software Engineer',
+  companyId: 'company-1',
+  url: 'https://example.com/jobs/1',
+  source: 'manual',
+  description: 'Full JD text here.',
+  location: 'New York, NY',
+  remote: false,
+  salary: 120000,
+  workAuthorizationRequired: null,
+  score: null,
+  scoreJustification: null,
+  status: 'new',
+  appliedProfileId: null,
+  tailoredResumePath: null,
+  tailoredResumePdfPath: null,
+  coverLetterPath: null,
+  coverLetterPdfPath: null,
+  screenshotPath: null,
+  outreachDraftPath: null,
+});
+
+// ---------------------------------------------------------------------------
+// initDb
+// ---------------------------------------------------------------------------
 
 describe('initDb', () => {
-  it.todo('creates wolf.sqlite in the data/ subdirectory');
-  it.todo('is idempotent — calling twice does not throw');
+  it('creates tables — jobs table is queryable after init', async () => {
+    const jobs = await getJobs({});
+    expect(jobs).toEqual([]);
+  });
+
+  it('is idempotent — calling twice does not throw', async () => {
+    await expect(initDb(':memory:')).resolves.not.toThrow();
+  });
 });
+
+// ---------------------------------------------------------------------------
+// upsertCompany
+// ---------------------------------------------------------------------------
 
 describe('upsertCompany', () => {
-  it.todo('inserts a new company and returns its id');
-  it.todo('returns the same id for a duplicate company name (case-insensitive)');
+  it('inserts a new company and returns its id', async () => {
+    const id = await upsertCompany({ name: 'Google', domain: null, linkedinUrl: null, size: null, industry: null, headquartersLocation: null, notes: null });
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('returns the same id for a duplicate company name (case-insensitive)', async () => {
+    const id1 = await upsertCompany({ name: 'Google', domain: null, linkedinUrl: null, size: null, industry: null, headquartersLocation: null, notes: null });
+    const id2 = await upsertCompany({ name: 'google', domain: null, linkedinUrl: null, size: null, industry: null, headquartersLocation: null, notes: null });
+    expect(id1).toBe(id2);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// getCompany
+// ---------------------------------------------------------------------------
 
 describe('getCompany', () => {
-  it.todo('returns the company after insertion');
-  it.todo('returns null for unknown id');
+  it('returns the company after insertion', async () => {
+    const id = await upsertCompany({ name: 'Meta', domain: 'meta.com', linkedinUrl: null, size: null, industry: null, headquartersLocation: null, notes: null });
+    const company = await getCompany(id);
+    expect(company?.name).toBe('Meta');
+    expect(company?.domain).toBe('meta.com');
+  });
+
+  it('returns null for unknown id', async () => {
+    const result = await getCompany('nonexistent-id');
+    expect(result).toBeNull();
+  });
 });
+
+// ---------------------------------------------------------------------------
+// saveJob
+// ---------------------------------------------------------------------------
 
 describe('saveJob', () => {
-  it.todo('saves a job and returns a non-empty id');
-  it.todo('persists all fields correctly');
+  it('saves a job and returns a non-empty id', async () => {
+    const id = await saveJob(baseJob());
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('persists all fields correctly', async () => {
+    const job = { ...baseJob(), title: 'Staff Engineer', remote: true, salary: 'unpaid' as const };
+    const id = await saveJob(job);
+    const saved = await getJob(id);
+    expect(saved?.title).toBe('Staff Engineer');
+    expect(saved?.remote).toBe(true);
+    expect(saved?.salary).toBe('unpaid');
+  });
 });
+
+// ---------------------------------------------------------------------------
+// saveJobs (bulk)
+// ---------------------------------------------------------------------------
 
 describe('saveJobs (bulk)', () => {
-  it.todo('inserts multiple jobs and returns the inserted count');
-  it.todo('skips duplicates with the same (source, url)');
+  it('inserts multiple jobs and returns the inserted count', async () => {
+    const jobs = [
+      { ...baseJob(), url: 'https://example.com/1' },
+      { ...baseJob(), url: 'https://example.com/2' },
+    ];
+    const count = await saveJobs(jobs);
+    expect(count).toBe(2);
+  });
+
+  it('skips duplicates with the same (source, url)', async () => {
+    const job = { ...baseJob(), url: 'https://example.com/dup' };
+    await saveJob(job);
+    const count = await saveJobs([job]);
+    expect(count).toBe(0);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// getJobs
+// ---------------------------------------------------------------------------
 
 describe('getJobs', () => {
-  it.todo('returns all jobs when no filters are set');
-  it.todo('filters by status');
-  it.todo('filters by minScore');
+  it('returns all jobs when no filters are set', async () => {
+    await saveJob({ ...baseJob(), url: 'https://a.com' });
+    await saveJob({ ...baseJob(), url: 'https://b.com' });
+    const jobs = await getJobs({});
+    expect(jobs.length).toBe(2);
+  });
+
+  it('filters by status', async () => {
+    await saveJob({ ...baseJob(), url: 'https://a.com', status: 'new' });
+    await saveJob({ ...baseJob(), url: 'https://b.com', status: 'applied' });
+    const jobs = await getJobs({ status: 'new' });
+    expect(jobs.length).toBe(1);
+    expect(jobs[0]!.status).toBe('new');
+  });
+
+  it('filters by minScore', async () => {
+    await saveJob({ ...baseJob(), url: 'https://a.com', score: 0.9 });
+    await saveJob({ ...baseJob(), url: 'https://b.com', score: 0.3 });
+    const jobs = await getJobs({ minScore: 0.5 });
+    expect(jobs.length).toBe(1);
+    expect(jobs[0]!.score).toBe(0.9);
+  });
 });
+
+// ---------------------------------------------------------------------------
+// updateJob
+// ---------------------------------------------------------------------------
 
 describe('updateJob', () => {
-  it.todo('updates specific fields without touching others');
-  it.todo('throws if the job does not exist');
+  it('updates specific fields without touching others', async () => {
+    const id = await saveJob(baseJob());
+    await updateJob(id, { status: 'applied', score: 0.85 });
+    const updated = await getJob(id);
+    expect(updated?.status).toBe('applied');
+    expect(updated?.score).toBe(0.85);
+    expect(updated?.title).toBe('Software Engineer'); // unchanged
+  });
+
+  it('throws if the job does not exist', async () => {
+    await expect(updateJob('ghost-id', { status: 'applied' })).rejects.toThrow('ghost-id');
+  });
 });
+
+// ---------------------------------------------------------------------------
+// countByStatus
+// ---------------------------------------------------------------------------
 
 describe('countByStatus', () => {
-  it.todo('returns 0 for all statuses when DB is empty');
-  it.todo('counts correctly after inserting jobs');
+  it('returns 0 for all statuses when DB is empty', async () => {
+    const counts = await countByStatus();
+    expect(counts.new).toBe(0);
+    expect(counts.applied).toBe(0);
+    expect(counts.rejected).toBe(0);
+  });
+
+  it('counts correctly after inserting jobs', async () => {
+    await saveJob({ ...baseJob(), url: 'https://a.com', status: 'new' });
+    await saveJob({ ...baseJob(), url: 'https://b.com', status: 'new' });
+    await saveJob({ ...baseJob(), url: 'https://c.com', status: 'applied' });
+    const counts = await countByStatus();
+    expect(counts.new).toBe(2);
+    expect(counts.applied).toBe(1);
+  });
 });
 
+// ---------------------------------------------------------------------------
+// saveBatch / getPendingBatches / updateBatchStatus
+// ---------------------------------------------------------------------------
+
 describe('saveBatch / getPendingBatches / updateBatchStatus', () => {
-  it.todo('saves a batch and returns a local id');
-  it.todo('returns the batch in getPendingBatches');
-  it.todo('removes batch from pending after marking completed');
+  it('saves a batch and returns a local id', async () => {
+    const id = await saveBatch('batch-abc', 'score', 'anthropic', 'default');
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('returns the batch in getPendingBatches', async () => {
+    await saveBatch('batch-abc', 'score', 'anthropic', 'default');
+    const pending = await getPendingBatches();
+    expect(pending.length).toBe(1);
+    expect(pending[0]!.batchId).toBe('batch-abc');
+    expect(pending[0]!.status).toBe('pending');
+  });
+
+  it('removes batch from pending after marking completed', async () => {
+    const id = await saveBatch('batch-abc', 'score', 'anthropic', 'default');
+    await updateBatchStatus(id, 'completed');
+    const pending = await getPendingBatches();
+    expect(pending.length).toBe(0);
+  });
 });

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -2,58 +2,33 @@
  * db.ts — Local SQLite database access layer.
  *
  * All wolf commands read and write through this module.
- * No command should import better-sqlite3 directly — use these functions instead.
+ * No command should import better-sqlite3 or drizzle directly — use these functions instead.
  *
  * Database file: <workspace>/data/wolf.sqlite
  * Created automatically on first use.
  *
- * ## Schema overview
- *
- * companies
- *   id TEXT PRIMARY KEY        -- uuid
- *   name TEXT NOT NULL
- *   domain TEXT                -- used by reach to infer email patterns
- *   size TEXT                  -- CompanySize enum value
- *   createdAt TEXT NOT NULL
- *   updatedAt TEXT NOT NULL
- *
- * jobs
- *   id TEXT PRIMARY KEY        -- uuid
- *   title TEXT NOT NULL
- *   companyId TEXT NOT NULL    -- FK → companies.id
- *   url TEXT NOT NULL
- *   source TEXT NOT NULL       -- provider name, e.g. "linkedin", "api", "manual"
- *   description TEXT NOT NULL  -- full JD text
- *   location TEXT NOT NULL
- *   remote INTEGER NOT NULL    -- 0 or 1
- *   salary TEXT                -- JSON: number | "unpaid" | null
- *   workAuthorizationRequired TEXT
- *   score REAL                 -- null if unscored
- *   scoreJustification TEXT    -- AI explanation of score
- *   status TEXT NOT NULL       -- JobStatus value
- *   appliedProfileId TEXT
- *   tailoredResumePath TEXT
- *   tailoredResumePdfPath TEXT
- *   coverLetterPath TEXT
- *   coverLetterPdfPath TEXT
- *   screenshotPath TEXT
- *   outreachDraftPath TEXT
- *   createdAt TEXT NOT NULL
- *   updatedAt TEXT NOT NULL
- *
- * batches
- *   id TEXT PRIMARY KEY        -- uuid (local)
- *   batchId TEXT NOT NULL      -- provider-assigned batch ID (Anthropic or OpenAI)
- *   type TEXT NOT NULL         -- "score" | "tailor" | ...
- *   aiProvider TEXT NOT NULL   -- "anthropic" | "openai"
- *   profileId TEXT NOT NULL    -- which profile was active when the batch was submitted
- *   status TEXT NOT NULL       -- "pending" | "completed" | "failed" | "partial_failed"
- *   submittedAt TEXT NOT NULL
- *   completedAt TEXT           -- null until done
+ * Schema is defined in schema.ts — the single source of truth for table structure and types.
  */
 
+import BetterSqlite3 from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { eq, gte, inArray, sql } from 'drizzle-orm';
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { companies, jobs, batches } from './schema.js';
 import type { Job, JobQuery, JobUpdate, JobStatus } from '../types/index.js';
 import type { Company } from '../types/index.js';
+
+type DrizzleDb = ReturnType<typeof drizzle>;
+
+// Module-level singleton — set once by initDb(), used by all other functions.
+let db: DrizzleDb | null = null;
+
+function getDb(): DrizzleDb {
+  if (!db) throw new Error('Database not initialized. Call initDb() first.');
+  return db;
+}
 
 // ---------------------------------------------------------------------------
 // Initialization
@@ -64,16 +39,73 @@ import type { Company } from '../types/index.js';
  * Creates all tables if they do not exist.
  * Must be called once before any other db function.
  *
- * @param workspaceDir - Absolute path to the workspace directory (process.cwd()).
- * @throws If the data/ directory cannot be created or the database cannot be opened.
+ * @param workspaceDir - Absolute path to the workspace directory, or ':memory:' for tests.
  */
 export async function initDb(workspaceDir: string): Promise<void> {
-  // TODO(M2):
-  // 1. Ensure <workspaceDir>/data/ directory exists (mkdir -p)
-  // 2. Open better-sqlite3 connection to <workspaceDir>/data/wolf.sqlite
-  // 3. Run CREATE TABLE IF NOT EXISTS for companies, jobs, batches (see schema above)
-  // 4. Store the connection in a module-level variable for reuse
-  throw new Error('Not implemented');
+  let dbPath: string;
+  if (workspaceDir === ':memory:') {
+    dbPath = ':memory:';
+  } else {
+    const dataDir = path.join(workspaceDir, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    dbPath = path.join(dataDir, 'wolf.sqlite');
+  }
+
+  const sqlite = new BetterSqlite3(dbPath);
+  db = drizzle(sqlite);
+
+  // Create tables if they don't exist.
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS companies (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      domain TEXT,
+      linkedinUrl TEXT,
+      size TEXT,
+      industry TEXT,
+      headquartersLocation TEXT,
+      notes TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS jobs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      companyId TEXT NOT NULL,
+      url TEXT NOT NULL,
+      source TEXT NOT NULL,
+      description TEXT NOT NULL,
+      location TEXT NOT NULL,
+      remote INTEGER NOT NULL,
+      salary TEXT,
+      workAuthorizationRequired TEXT,
+      score REAL,
+      scoreJustification TEXT,
+      status TEXT NOT NULL,
+      appliedProfileId TEXT,
+      tailoredResumePath TEXT,
+      tailoredResumePdfPath TEXT,
+      coverLetterPath TEXT,
+      coverLetterPdfPath TEXT,
+      screenshotPath TEXT,
+      outreachDraftPath TEXT,
+      createdAt TEXT NOT NULL,
+      updatedAt TEXT NOT NULL,
+      UNIQUE(source, url)
+    );
+
+    CREATE TABLE IF NOT EXISTS batches (
+      id TEXT PRIMARY KEY,
+      batchId TEXT NOT NULL,
+      type TEXT NOT NULL,
+      aiProvider TEXT NOT NULL,
+      profileId TEXT NOT NULL,
+      status TEXT NOT NULL,
+      submittedAt TEXT NOT NULL,
+      completedAt TEXT
+    );
+  `);
 }
 
 // ---------------------------------------------------------------------------
@@ -89,12 +121,20 @@ export async function initDb(workspaceDir: string): Promise<void> {
 export async function upsertCompany(
   company: Omit<Company, 'id' | 'createdAt' | 'updatedAt'>
 ): Promise<string> {
-  // TODO(M2):
-  // 1. SELECT id FROM companies WHERE LOWER(name) = LOWER(company.name)
-  // 2. If found, return existing id
-  // 3. If not found, INSERT new row with uuid, set createdAt/updatedAt to now
-  // 4. Return new id
-  throw new Error('Not implemented');
+  const database = getDb();
+
+  const existing = await database
+    .select({ id: companies.id })
+    .from(companies)
+    .where(sql`LOWER(${companies.name}) = LOWER(${company.name})`)
+    .limit(1);
+
+  if (existing.length > 0) return existing[0]!.id;
+
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  await database.insert(companies).values({ id, ...company, createdAt: now, updatedAt: now });
+  return id;
 }
 
 /**
@@ -102,8 +142,8 @@ export async function upsertCompany(
  * @returns The Company, or null if not found.
  */
 export async function getCompany(id: string): Promise<Company | null> {
-  // TODO(M2): SELECT * FROM companies WHERE id = ?
-  throw new Error('Not implemented');
+  const rows = await getDb().select().from(companies).where(eq(companies.id, id)).limit(1);
+  return (rows[0] as Company | undefined) ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -120,30 +160,29 @@ export async function getCompany(id: string): Promise<Company | null> {
 export async function saveJob(
   job: Omit<Job, 'id' | 'createdAt' | 'updatedAt'>
 ): Promise<string> {
-  // TODO(M2):
-  // 1. Generate uuid for id
-  // 2. Set createdAt = updatedAt = new Date().toISOString()
-  // 3. INSERT INTO jobs with all fields
-  // 4. Return id
-  throw new Error('Not implemented');
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  await getDb().insert(jobs).values({ id, ...job, createdAt: now, updatedAt: now });
+  return id;
 }
 
 /**
  * Saves multiple jobs in a single transaction.
  * Skips duplicates: if a job with the same (source, url) already exists, it is ignored.
  *
- * @param jobs - Array of jobs to insert.
  * @returns Number of jobs actually inserted (duplicates excluded).
  */
 export async function saveJobs(
-  jobs: Omit<Job, 'id' | 'createdAt' | 'updatedAt'>[]
+  jobList: Omit<Job, 'id' | 'createdAt' | 'updatedAt'>[]
 ): Promise<number> {
-  // TODO(M2):
-  // 1. Begin transaction
-  // 2. For each job, check if (source, url) already exists — skip if so
-  // 3. INSERT new jobs (call saveJob logic inside the transaction)
-  // 4. Commit and return count of inserted rows
-  throw new Error('Not implemented');
+  if (jobList.length === 0) return 0;
+  const now = new Date().toISOString();
+  const rows = jobList.map(job => ({ id: randomUUID(), ...job, createdAt: now, updatedAt: now }));
+  const result = await getDb()
+    .insert(jobs)
+    .values(rows)
+    .onConflictDoNothing();
+  return result.changes ?? 0;
 }
 
 /**
@@ -151,27 +190,41 @@ export async function saveJobs(
  * @returns The Job, or null if not found.
  */
 export async function getJob(id: string): Promise<Job | null> {
-  // TODO(M2): SELECT * FROM jobs WHERE id = ?
-  throw new Error('Not implemented');
+  const rows = await getDb().select().from(jobs).where(eq(jobs.id, id)).limit(1);
+  return (rows[0] as Job | undefined) ?? null;
 }
 
 /**
  * Queries jobs with optional filters. Returns all jobs if no filters are set.
  *
- * @param query - Filters: status, companyIds, minScore, since (ISO 8601), source, limit, offset.
+ * @param query - Filters: status, companyIds, minScore, since, source, limit, offset.
  * @returns Matching jobs ordered by createdAt DESC.
  */
 export async function getJobs(query: JobQuery): Promise<Job[]> {
-  // TODO(M2):
-  // 1. Build WHERE clause dynamically from non-null query fields
-  //    - status: single value or array → WHERE status IN (...)
-  //    - companyIds: WHERE companyId IN (...)
-  //    - minScore: WHERE score >= ?
-  //    - since: WHERE createdAt >= ?
-  //    - source: WHERE source = ?
-  // 2. Apply LIMIT / OFFSET if set
-  // 3. Return rows mapped to Job objects
-  throw new Error('Not implemented');
+  let q = getDb().select().from(jobs).$dynamic();
+
+  if (query.status !== undefined) {
+    const statuses = Array.isArray(query.status) ? query.status : [query.status];
+    q = q.where(inArray(jobs.status, statuses));
+  }
+  if (query.companyIds !== undefined && query.companyIds.length > 0) {
+    q = q.where(inArray(jobs.companyId, query.companyIds));
+  }
+  if (query.minScore !== undefined) {
+    q = q.where(gte(jobs.score, query.minScore));
+  }
+  if (query.since !== undefined) {
+    q = q.where(gte(jobs.createdAt, query.since));
+  }
+  if (query.source !== undefined) {
+    q = q.where(eq(jobs.source, query.source));
+  }
+
+  q = q.orderBy(sql`${jobs.createdAt} DESC`);
+  if (query.limit !== undefined) q = q.limit(query.limit);
+  if (query.offset !== undefined) q = q.offset(query.offset);
+
+  return q as unknown as Promise<Job[]>;
 }
 
 /**
@@ -181,26 +234,22 @@ export async function getJobs(query: JobQuery): Promise<Job[]> {
  * @throws If no job with the given id exists.
  */
 export async function updateJob(id: string, update: JobUpdate): Promise<void> {
-  // TODO(M2):
-  // 1. Build SET clause from non-undefined fields in update
-  // 2. Always add updatedAt = now
-  // 3. UPDATE jobs SET ... WHERE id = ?
-  // 4. Throw if rowsAffected === 0 (job not found)
-  throw new Error('Not implemented');
+  const result = await getDb()
+    .update(jobs)
+    .set({ ...update, updatedAt: new Date().toISOString() })
+    .where(eq(jobs.id, id));
+  if (result.changes === 0) throw new Error(`Job not found: ${id}`);
 }
 
 /**
- * Updates multiple jobs in a single transaction (e.g. bulk status change).
- *
- * @param ids - Job ids to update.
- * @param update - Fields to apply to all of them.
+ * Updates multiple jobs in a single transaction.
  */
 export async function updateJobs(ids: string[], update: JobUpdate): Promise<void> {
-  // TODO(M2):
-  // 1. Begin transaction
-  // 2. Call updateJob for each id
-  // 3. Commit
-  throw new Error('Not implemented');
+  if (ids.length === 0) return;
+  await getDb()
+    .update(jobs)
+    .set({ ...update, updatedAt: new Date().toISOString() })
+    .where(inArray(jobs.id, ids));
 }
 
 // ---------------------------------------------------------------------------
@@ -209,16 +258,23 @@ export async function updateJobs(ids: string[], update: JobUpdate): Promise<void
 
 /**
  * Counts jobs grouped by status.
- * Used by `wolf status` to show the summary row.
- *
  * @returns A record mapping each JobStatus to its count (0 if none).
  */
 export async function countByStatus(): Promise<Record<JobStatus, number>> {
-  // TODO(M2):
-  // 1. SELECT status, COUNT(*) FROM jobs GROUP BY status
-  // 2. Map results to Record<JobStatus, number>
-  // 3. Fill in 0 for any status not present in results
-  throw new Error('Not implemented');
+  const allStatuses: JobStatus[] = [
+    'new', 'reviewed', 'ignored', 'filtered', 'applied', 'interview', 'offer', 'rejected',
+  ];
+  const result = Object.fromEntries(allStatuses.map(s => [s, 0])) as Record<JobStatus, number>;
+
+  const rows = await getDb()
+    .select({ status: jobs.status, count: sql<number>`COUNT(*)` })
+    .from(jobs)
+    .groupBy(jobs.status);
+
+  for (const row of rows) {
+    result[row.status as JobStatus] = row.count;
+  }
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -227,26 +283,18 @@ export async function countByStatus(): Promise<Record<JobStatus, number>> {
 
 /** Represents one AI batch job tracked in the batches table. */
 export interface BatchRecord {
-  id: string;           // local uuid
-  batchId: string;      // provider-assigned ID (Anthropic / OpenAI)
-  type: string;         // "score" | "tailor" | ...
-  aiProvider: string;   // "anthropic" | "openai"
-  profileId: string;    // which profile was used — needed by pollAll() to reload the profile
+  id: string;
+  batchId: string;
+  type: string;
+  aiProvider: string;
+  profileId: string;
   status: 'pending' | 'completed' | 'failed' | 'partial_failed';
-  // partial_failed: batch ended but some individual items errored.
-  // Successful items are written to DB; failed items remain score: null
-  // and will be picked up automatically on the next wolf score run.
-  submittedAt: string;  // ISO 8601
+  submittedAt: string;
   completedAt: string | null;
 }
 
 /**
  * Records a newly submitted AI batch job.
- *
- * @param batchId - The ID returned by the AI provider's batch API.
- * @param type - Command type: "score", "tailor", etc.
- * @param aiProvider - "anthropic" or "openai".
- * @param profileId - The profile used when the batch was submitted.
  * @returns The local batch record id.
  */
 export async function saveBatch(
@@ -255,32 +303,36 @@ export async function saveBatch(
   aiProvider: string,
   profileId: string
 ): Promise<string> {
-  // TODO(M2):
-  // 1. INSERT INTO batches with uuid, batchId, type, aiProvider, profileId, status='pending', submittedAt=now
-  // 2. Return local id
-  throw new Error('Not implemented');
+  const id = randomUUID();
+  await getDb().insert(batches).values({
+    id, batchId, type, aiProvider, profileId,
+    status: 'pending',
+    submittedAt: new Date().toISOString(),
+    completedAt: null,
+  });
+  return id;
 }
 
 /**
  * Returns all batches with status 'pending'.
- * Called by poll logic to know which batches to check.
  */
 export async function getPendingBatches(): Promise<BatchRecord[]> {
-  // TODO(M2): SELECT * FROM batches WHERE status = 'pending' ORDER BY submittedAt ASC
-  throw new Error('Not implemented');
+  return getDb()
+    .select()
+    .from(batches)
+    .where(eq(batches.status, 'pending'))
+    .orderBy(batches.submittedAt) as unknown as Promise<BatchRecord[]>;
 }
 
 /**
- * Marks a batch as completed or failed, and records the completion time.
- *
- * @param id - Local batch record id (not the provider batchId).
- * @param status - "completed", "failed", or "partial_failed".
+ * Marks a batch as completed or failed.
  */
 export async function updateBatchStatus(
   id: string,
   status: 'completed' | 'failed' | 'partial_failed'
 ): Promise<void> {
-  // TODO(M2):
-  // 1. UPDATE batches SET status = ?, completedAt = now WHERE id = ?
-  throw new Error('Not implemented');
+  await getDb()
+    .update(batches)
+    .set({ status, completedAt: new Date().toISOString() })
+    .where(eq(batches.id, id));
 }

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,58 @@
+/**
+ * schema.ts — Drizzle ORM table definitions.
+ *
+ * This is the single source of truth for the database schema.
+ * TypeScript types for all rows are inferred from here — no manual mapping needed.
+ */
+
+import { sqliteTable, text, real, integer } from 'drizzle-orm/sqlite-core';
+import type { CompanySize } from '../types/index.js';
+
+export const companies = sqliteTable('companies', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  domain: text('domain'),
+  linkedinUrl: text('linkedinUrl'),
+  size: integer('size').$type<CompanySize | null>(),
+  industry: text('industry'),
+  headquartersLocation: text('headquartersLocation'),
+  notes: text('notes'),
+  createdAt: text('createdAt').notNull(),
+  updatedAt: text('updatedAt').notNull(),
+});
+
+export const jobs = sqliteTable('jobs', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  companyId: text('companyId').notNull(),
+  url: text('url').notNull(),
+  source: text('source').notNull(),
+  description: text('description').notNull(),
+  location: text('location').notNull(),
+  remote: integer('remote', { mode: 'boolean' }).notNull(),
+  salary: text('salary', { mode: 'json' }).$type<number | 'unpaid' | null>(),
+  workAuthorizationRequired: text('workAuthorizationRequired'),
+  score: real('score'),
+  scoreJustification: text('scoreJustification'),
+  status: text('status').notNull(),
+  appliedProfileId: text('appliedProfileId'),
+  tailoredResumePath: text('tailoredResumePath'),
+  tailoredResumePdfPath: text('tailoredResumePdfPath'),
+  coverLetterPath: text('coverLetterPath'),
+  coverLetterPdfPath: text('coverLetterPdfPath'),
+  screenshotPath: text('screenshotPath'),
+  outreachDraftPath: text('outreachDraftPath'),
+  createdAt: text('createdAt').notNull(),
+  updatedAt: text('updatedAt').notNull(),
+});
+
+export const batches = sqliteTable('batches', {
+  id: text('id').primaryKey(),
+  batchId: text('batchId').notNull(),
+  type: text('type').notNull(),
+  aiProvider: text('aiProvider').notNull(),
+  profileId: text('profileId').notNull(),
+  status: text('status').notNull(),
+  submittedAt: text('submittedAt').notNull(),
+  completedAt: text('completedAt'),
+});


### PR DESCRIPTION
## Summary
- Implement `db.ts` using Drizzle ORM on top of better-sqlite3 — single source of truth for schema via `schema.ts`, no manual row mapping
- Implement `wolf add` command: upserts company, saves job with `status: new`, configurable `source` field (defaults to `'manual'`, extensible for browser plugin etc.)
- Extend `AddOptions` with `location`, `remote`, `salary`, `workAuthorizationRequired`, `source`

## Test plan
- [x] `npm test` — all db.ts tests (20) and add tests (6) pass
- [x] `npx tsc --noEmit` — no type errors