### PR TITLE
feat(m3-enhancements): tailor pipeline fixes + init polish

### DIFF
--- a/src/application/impl/tailorApplicationServiceImpl.ts
+++ b/src/application/impl/tailorApplicationServiceImpl.ts
@@ -42,10 +42,13 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
 
     const resumePool = await this.profileRepository.getResumePool(profile.id);
 
-    // Create output directory: data/<company>_<title>_<jobId>/
+    // Create output directories:
+    //   data/<company>_<title>_<jobId>/         — PDFs (final output)
+    //   data/<company>_<title>_<jobId>/src/     — HTML source (for prompt inspection)
     const dirName = `${sanitize(job.companyId)}_${sanitize(job.title)}_${jobId}`;
     const outputDir = path.join(this.workspaceDir, 'data', dirName);
-    await mkdir(outputDir, { recursive: true });
+    const srcDir = path.join(outputDir, 'src');
+    await mkdir(srcDir, { recursive: true });
 
     // --- Resume ---
     // Rewrite resume pool into tailored HTML body matching this JD, then render to PDF.
@@ -55,6 +58,8 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
       profile,
       aiConfig,
     );
+    // Save HTML source for inspection alongside the PDF.
+    await writeFile(path.join(srcDir, 'resume.html'), htmlBody);
     const pdfBuffer = await this.renderService.renderPdf(htmlBody);
     const pdfPath = path.join(outputDir, 'resume.pdf');
     await writeFile(pdfPath, pdfBuffer);
@@ -71,8 +76,8 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
         this.defaultCoverLetterTone,
         aiConfig,
       );
-      // Write HTML source for debugging (raw fragment — useful for prompt iteration)
-      coverLetterHtmlPath = path.join(outputDir, 'cover_letter.html');
+      // Save HTML source for inspection.
+      coverLetterHtmlPath = path.join(srcDir, 'cover_letter.html');
       await writeFile(coverLetterHtmlPath, clHtml);
       // Render to PDF using simple renderer (no fit algorithm — cover letters don't need forced one-page)
       const clPdfBuffer = await this.renderService.renderCoverLetterPdf(clHtml);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { fill } from '../commands/fill/index.js';
 import { reach } from '../commands/reach/index.js';
 import { status } from '../commands/status/index.js';
 import { init } from '../commands/init/index.js';
+import { add } from '../commands/add/index.js';
 import { envShow, envSet, envClear } from '../commands/env/index.js';
 import { startMcpServer } from '../mcp/server.js';
 
@@ -22,6 +23,25 @@ program
   .description('Interactive setup wizard')
   .action(async () => {
     await init();
+  });
+
+program
+  .command('add')
+  .description('Add a job manually')
+  .requiredOption('-t, --title <title>', 'Job title')
+  .requiredOption('-c, --company <company>', 'Company name')
+  .requiredOption('-j, --jd-text <text>', 'Job description text')
+  .option('-u, --url <url>', 'Original job posting URL')
+  .option('-p, --profile <id>', 'Profile to use')
+  .action(async (opts) => {
+    const result = await add({
+      title: opts.title,
+      company: opts.company,
+      jdText: opts.jdText,
+      url: opts.url,
+      profileId: opts.profile,
+    });
+    console.log(JSON.stringify(result, null, 2));
   });
 
 program

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -18,39 +18,111 @@ const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 function buildResumePoolTemplate(name: string): string {
   return `# Resume Pool — ${name}
 
-<!--
-  This is your "everything" resume — wolf reads this and selects the most relevant
-  content for each job. Include ALL experience, projects, and skills, even older ones.
-  wolf will pick the right subset per application.
--->
+// This is your "everything" resume — wolf reads this and selects the most relevant
+// content for each job. Include ALL experience, projects, and skills, even older ones.
+// wolf will pick the right subset per application.
+// LINES STARTING WITH // ARE NOTES FOR YOU ONLY — THE AI WILL NOT READ THEM.
 
-## Contact
-Name: ${name}
-Email:
-Phone:
-LinkedIn:
-GitHub:
+// ## Contact
+// Your contact info (name, email, phone, LinkedIn, etc.) is NOT stored here.
+// To update it, edit: profiles/default/profile.toml
+
 
 ## Experience
 
+// List every role, including short stints and older jobs — wolf picks what's relevant.
+// Use strong action verbs and include metrics where possible (e.g. "reduced latency by 40%").
+
 ### Job Title — Company Name
-*Month Year – Month Year (or Present)*
+*Month Year - Month Year (or Present)*
 - Bullet describing impact or responsibility
 - Bullet with metrics if available
+
+// ## Projects
+// Include personal, open-source, and side projects — not just work projects.
+// Mention the tech stack and what problem it solved.
 
 ## Projects
 
 ### Project Name
 *Year*
-- What it does and what you built
+- What it does, what you built, and what tech you used
 
 ## Education
 
+// List degrees in reverse chronological order. Include GPA if 3.5+.
+// Relevant coursework is optional but useful for new grads.
+
 ### Degree — University Name
-*Year – Year*
+*Year - Year*
 
 ## Skills
+// Comma-separated list. Group loosely by category if helpful (e.g. Languages, Tools, Platforms).
+// wolf will reformat this to match the JD's preferred phrasing.
+
 TypeScript, Python, SQL, ...
+
+// ## Certifications (optional)
+// Include professional certs: AWS, GCP, Azure, PMP, CFA, etc.
+// Add the issuing body and year.
+
+// ## Certifications (optional)
+// - AWS Certified Solutions Architect — Amazon, 2024
+// - Google Cloud Professional Data Engineer — Google, 2023
+
+// ## Awards & Honors (optional)
+// Hackathon wins, academic honors, competitive programming, scholarships.
+// Even older awards are worth keeping — wolf will decide if they're relevant.
+
+// ## Awards & Honors (optional)
+// - 1st Place — HackMIT 2023
+// - Dean's List — University Name, 2019–2021
+
+// ## Publications (optional)
+// Research papers, technical blog posts, or articles. Important for ML/research roles.
+// Include venue/journal and year.
+
+// ## Publications (optional)
+// - "Paper Title" — NeurIPS 2023
+// - "Blog Post Title" — Personal blog, 2024 (link)
+
+// ## Open Source (optional)
+// Notable contributions beyond your own projects. Include repo links and impact.
+// Especially valuable if contributions are to well-known projects.
+
+// ## Open Source (optional)
+// - Contributor to facebook/react — fixed hydration bug, 200+ stars on PR
+// - Maintainer of your-lib (2.4k stars on GitHub)
+
+// ## Languages (optional)
+// Spoken/written languages. Useful for international or customer-facing roles.
+// Format: Language (Proficiency level).
+
+// ## Languages (optional)
+// - English (Native)
+// - Mandarin (Fluent)
+// - Spanish (Conversational)
+
+// ## Volunteer (optional)
+// Community work, non-profit, or mentoring. Shows character and range.
+// Rarely included unless directly relevant or the role values culture-add.
+
+// ## Volunteer (optional)
+// - Coding instructor — Code.org, 2022–present
+
+// ## Interests (optional)
+// Keep it brief and genuine — avoid generic hobbies like "reading" or "travel".
+// Best used when the company culture values personality fit.
+
+// ## Interests (optional)
+// Competitive chess, trail running, generative art
+
+// ## Speaking (optional)
+// Conference talks, panels, podcasts. More relevant for senior or staff roles.
+// Rarely included unless you speak regularly or the role involves evangelism.
+
+// ## Speaking (optional)
+// - "Talk Title" — Conference Name, Year
 `;
 }
 
@@ -222,7 +294,17 @@ Consider cd-ing to a dedicated folder first, e.g.:
   if (profileExists) {
     console.log(dim('profiles/default/profile.toml already exists — skipping (edit manually to update)'));
   } else {
-    await fs.writeFile(profileTomlPath, stringify(profile as unknown as Record<string, unknown>), 'utf-8');
+    // Replace null with "" so optional fields always appear in the file.
+    // smol-toml skips null entirely (TOML has no null type), which would hide
+    // fields from users who want to fill them in later.
+    const serializable = {
+      ...profile,
+      firstUrl:     profile.firstUrl     ?? '',
+      secondUrl:    profile.secondUrl    ?? '',
+      thirdUrl:     profile.thirdUrl     ?? '',
+      scoringNotes: profile.scoringNotes ?? '',
+    };
+    await fs.writeFile(profileTomlPath, stringify(serializable as unknown as Record<string, unknown>), 'utf-8');
   }
 
   // ── Step 4: Write profiles/default/resume_pool.md (only if absent) ───────

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -156,8 +156,9 @@ Consider cd-ing to a dedicated folder first, e.g.:
     validate: v => v.trim() !== '' || 'Required',
   });
 
-  // Enumerate immigration status so the value matches the Status union type exactly.
-  const immigrationStatus = await select({
+  // Select from common statuses; "Other" allows free-form entry for multi-status
+  // situations (e.g. "H-1B + 485 pending") or non-US work authorizations.
+  const immigrationStatusRaw = await select({
     message: 'Work authorization status:',
     choices: [
       { name: 'No limit (citizen / GC / EAD)', value: 'no limit' },
@@ -165,8 +166,15 @@ Consider cd-ing to a dedicated folder first, e.g.:
       { name: 'L1',                             value: 'L1' },
       { name: 'OPT (STEM extension)',           value: 'OPT' },
       { name: 'CPT',                            value: 'CPT' },
+      { name: 'Other / multiple statuses',      value: '__other__' },
     ],
   });
+  const immigrationStatus = immigrationStatusRaw === '__other__'
+    ? await input({
+        message: 'Any other status, or multiple statuses:',
+        validate: v => v.trim() !== '' || 'Required',
+      })
+    : immigrationStatusRaw;
 
   // Optional URLs — empty string collapses to null so the TOML stays clean.
   const firstUrlRaw  = await input({ message: 'LinkedIn URL  (Enter to skip):', default: '' });

--- a/src/service/__tests__/renderService.test.ts
+++ b/src/service/__tests__/renderService.test.ts
@@ -15,6 +15,7 @@ vi.mock('playwright', () => ({
         goto: vi.fn().mockResolvedValue(undefined),
         evaluate: vi.fn().mockResolvedValue(undefined),
         pdf: vi.fn().mockResolvedValue(Buffer.from('fake-pdf-bytes')),
+        setViewportSize: vi.fn().mockResolvedValue(undefined),
       }),
       close: vi.fn().mockResolvedValue(undefined),
     }),
@@ -78,13 +79,13 @@ describe('RenderService', () => {
     await expect(svc.renderPdf('<h2>Too little</h2>')).rejects.toThrow(CannotFillError);
   });
 
-  // renderCoverLetterPdf: skip fit, directly call page.pdf and return the buffer.
-  it('renderCoverLetterPdf returns pdf buffer without fit', async () => {
+  // renderCoverLetterPdf: reuses fit() so the PDF code path is identical to renderPdf.
+  it('renderCoverLetterPdf returns pdf buffer via fit', async () => {
     mockFit.mockResolvedValue({ pdf: FAKE_PDF, finalParams: {}, iterations: 1, trace: [] } as unknown as FitResult);
     const svc = new RenderServiceImpl();
     const result = await svc.renderCoverLetterPdf('<p>Cover letter content</p>');
     expect(result).toEqual(FAKE_PDF);
-    // fit should NOT be called for cover letter rendering
-    expect(mockFit).not.toHaveBeenCalled();
+    // fit IS called — cover letters are one page and share the same rendering path.
+    expect(mockFit).toHaveBeenCalledOnce();
   });
 });

--- a/src/service/impl/renderServiceImpl.ts
+++ b/src/service/impl/renderServiceImpl.ts
@@ -37,16 +37,20 @@ export class RenderServiceImpl implements RenderService {
     try {
       await page.emulateMedia({ media: 'print' });
       await page.goto('file://' + SHELL_PATH, { waitUntil: 'domcontentloaded' });
+      // Inject the HTML body into the shell's #resume-root container.
       await page.evaluate((html: string) => {
         const root = document.getElementById('resume-root');
         if (!root) throw new Error('shell.html is missing #resume-root element');
         root.innerHTML = html;
       }, htmlBody);
-      // Wait for fonts to finish loading before generating PDF.
+      // Wait for fonts to finish loading before measuring layout.
       await page.evaluate(() =>
         (document as unknown as { fonts: { ready: Promise<void> } }).fonts.ready
       );
-      return page.pdf({ printBackground: true, preferCSSPageSize: true });
+      // Reuse fit() — cover letters are one page and fit handles both overflow
+      // and underflow. This shares the exact same PDF code path as renderPdf().
+      const result = await fit(page);
+      return result.pdf;
     } finally {
       await browser.close();
     }

--- a/src/service/impl/resumeCoverLetterServiceImpl.ts
+++ b/src/service/impl/resumeCoverLetterServiceImpl.ts
@@ -1,11 +1,12 @@
 import { aiClient } from '../../utils/ai.js';
+import { stripComments } from '../../utils/stripComments.js';
 import type { ResumeCoverLetterService } from '../resumeCoverLetterService.js';
 import type { AiConfig, UserProfile } from '../../types/index.js';
 
 const SYSTEM_PROMPT = `You are a professional resume writer. Your job is to tailor a resume to a specific job description.
 
 You will be given:
-1. A resume pool in Markdown (all the candidate's experience, projects, education, skills)
+1. A resume pool in Markdown (all the candidate's experience, projects, education, skills, and optional sections)
 2. A job description
 3. Candidate contact info
 
@@ -31,13 +32,18 @@ Required HTML structure:
 <h2>Experience</h2>
 <div class="item">
   <div class="item-header"><span>Job Title, Company</span><span>Start – End</span></div>
-  <ul><li>Bullet rewritten to match JD keywords.</li></ul>
+  <ul>
+    <li>Bullet rewritten to match JD keywords — strong action verb, quantified impact.</li>
+    <li>3–5 bullets per role.</li>
+  </ul>
 </div>
 
 <h2>Projects</h2>
 <div class="item">
   <div class="item-header"><span>Project Name</span><span>Year</span></div>
-  <ul><li>Description.</li></ul>
+  <ul>
+    <li>What it does and how it relates to this JD — 3–5 bullets per project.</li>
+  </ul>
 </div>
 
 <h2>Education</h2>
@@ -47,15 +53,49 @@ Required HTML structure:
 
 <h2>Skills</h2>
 <div>Skill1, Skill2, Skill3</div>
+
+<!-- Render any other sections present in the resume pool using the same pattern -->
 \`\`\`
 
-Rules:
-- Select only the most relevant experiences and projects for this specific JD
-- Rewrite bullet points using keywords and phrasing from the JD where accurate
-- Do NOT fabricate experience, companies, or skills not present in the resume pool
-- Keep bullets concise — one sentence each, strong action verb first
-- Skills section: comma-separated list, no bullets
-- Output raw HTML only — no markdown fences, no explanation text`;
+## Step 1 — inventory (do this mentally before writing any HTML)
+
+Read the resume pool and list every section heading that has real content (not just comments).
+You MUST output ALL of them. Missing any section is a hard error, not a style choice.
+
+## Step 2 — output every section
+
+This is a ONE-PAGE resume. Every section must fit. Apply the hard limits below — do not exceed them.
+
+**Experience** (REQUIRED if present)
+- Include ALL roles — never drop a job.
+- HARD LIMIT: exactly 3 bullets per role.
+- Each bullet: 12–15 words max. Strong action verb, quantified result where possible.
+
+**Projects** (REQUIRED if present)
+- HARD LIMIT: pick the 2–3 most relevant projects only. Drop the rest.
+- HARD LIMIT: exactly 3 bullets per project.
+- Each bullet: 12–15 words max.
+
+**Education** (REQUIRED if present — do not skip)
+- All degrees. One line each: degree, institution, years. No bullets.
+
+**Skills** (REQUIRED if present — do not skip)
+- The pool may use markdown bold headers like **Category:** items.
+- Convert to plain comma-separated groups in HTML. No bold, no bullets.
+- Keep 10–12 most relevant skills for this JD.
+
+**Publications / Languages / Certifications / any other section** (REQUIRED if present — do not skip)
+- Include every section that exists in the pool. 1 item maximum per section, no bullets — one concise line.
+- Use the same .item structure as Experience/Projects.
+
+**Section order:** Experience → Projects → Education → Skills → remaining sections in pool order.
+
+## Output rules
+- Stay within the bullet and word limits above — the page cannot overflow.
+- The renderer will compress font/spacing to fit, but content limits are YOUR responsibility.
+- Do NOT fabricate experience, companies, or skills not present in the resume pool.
+- Output raw HTML only — no markdown fences, no explanation text.
+- Keep the CSS block exactly as shown; do not add extra styles.`;
 
 const COVER_LETTER_SYSTEM_PROMPT = `You are a professional cover letter writer.
 You will be given a resume pool, a job description, candidate contact info, and a tone.
@@ -109,7 +149,7 @@ Phone: ${profile.phone}
 URLs: ${urls || 'none'}
 
 ## Resume Pool
-${resumePool}
+${stripComments(resumePool)}
 
 ## Job Description
 ${jdText}
@@ -145,7 +185,7 @@ URLs: ${urls || 'none'}
 Tone: ${tone}
 
 ## Resume Pool
-${resumePool}
+${stripComments(resumePool)}
 
 ## Job Description
 ${jdText}

--- a/src/types/sponsorship.ts
+++ b/src/types/sponsorship.ts
@@ -10,10 +10,9 @@ export type Sponsorship =
 
 /**
  * Represents the candidate's work authorization status.
+ * Common values listed for reference; free-form strings are allowed to support
+ * multi-status situations (e.g. "H-1B + 485 pending") or non-US contexts.
+ *
+ * Common values: "H-1B" | "L1" | "OPT" | "CPT" | "no limit"
  */
-export type Status =
-  | "H-1B" // H-1B visa, or equivalent for other countries (e.g. Canada's LMIA work permits)
-  | "L1"   // L1 visa or equivalent single employer work permit
-  | "OPT"  // OPT STEM extension, or equivalent for other countries (e.g. Canada's post-graduation work permits)
-  | "CPT"  // CPT, or equivalent for other countries (e.g. Canada's co-op work permits)
-  | "no limit"; // e.g. US citizen or GC holder, H4 EAD, 485 EAD, or equivalent for other countries (e.g. Canadian permanent residents, UK settled status)
+export type Status = string;

--- a/src/utils/__tests__/stripComments.test.ts
+++ b/src/utils/__tests__/stripComments.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { stripComments } from '../stripComments.js';
+
+describe('stripComments()', () => {
+  // Normal content with no comments should pass through unchanged.
+  it('returns text unchanged when there are no comment lines', () => {
+    const input = '## Experience\n- Built something\n\n## Skills\nTypeScript';
+    expect(stripComments(input)).toBe(input);
+  });
+
+  // Lines starting with // should be removed entirely.
+  it('removes lines that start with //', () => {
+    const input = '// user note\n## Experience\n// another note\n- Built something';
+    expect(stripComments(input)).toBe('## Experience\n- Built something');
+  });
+
+  // Leading whitespace before // should still be treated as a comment line.
+  it('removes indented comment lines', () => {
+    const input = '  // indented note\n## Skills\nTypeScript';
+    expect(stripComments(input)).toBe('## Skills\nTypeScript');
+  });
+
+  // A URL like https://github.com must not be treated as a comment.
+  it('does not strip lines that contain // but do not start with //', () => {
+    const input = 'GitHub: https://github.com/user\n// actual comment';
+    expect(stripComments(input)).toBe('GitHub: https://github.com/user');
+  });
+
+  // Empty string should return empty string without error.
+  it('handles empty string', () => {
+    expect(stripComments('')).toBe('');
+  });
+});

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -51,7 +51,7 @@ export const anthropicClient: ProviderClient = async (
   const client = new Anthropic({ apiKey: process.env.WOLF_ANTHROPIC_API_KEY });
   const response = await client.messages.create({
     model,
-    max_tokens: 1024,
+    max_tokens: 4096,
     ...(systemPrompt ? { system: systemPrompt } : {}),
     messages: [{ role: "user", content: prompt }],
   });

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
 // --- Sponsorship enums ---
-export const StatusSchema = z.enum(['H-1B', 'L1', 'OPT', 'CPT', 'no limit']);
+// Free-form string — common values are H-1B, L1, OPT, CPT, "no limit",
+// but users may enter multi-status or non-US equivalents.
+export const StatusSchema = z.string().min(1);
 export const SponsorshipSchema = z.enum([
   'no sponsorship',
   'Green card',

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -19,14 +19,16 @@ export const UserProfileSchema = z.object({
   name: z.string(),
   email: z.string().email(),
   phone: z.string(),
-  firstUrl: z.string().nullable().default(null),
-  secondUrl: z.string().nullable().default(null),
-  thirdUrl: z.string().nullable().default(null),
+  // Empty string is treated as absent — written as "" when null so the field
+  // always appears in profile.toml, making it visible and easy to fill in later.
+  firstUrl: z.string().nullable().default(null).transform(v => v === '' ? null : v),
+  secondUrl: z.string().nullable().default(null).transform(v => v === '' ? null : v),
+  thirdUrl: z.string().nullable().default(null).transform(v => v === '' ? null : v),
   immigrationStatus: StatusSchema,
   willingToRelocate: z.boolean(),
   targetRoles: z.array(z.string()),
   targetLocations: z.array(z.string()),
-  scoringNotes: z.string().nullable().default(null),
+  scoringNotes: z.string().nullable().default(null).transform(v => v === '' ? null : v),
 });
 
 // --- AppConfig ---

--- a/src/utils/stripComments.ts
+++ b/src/utils/stripComments.ts
@@ -1,0 +1,18 @@
+/**
+ * Strips single-line comments from a markdown string before it is passed to an
+ * AI prompt. Any line whose first non-whitespace characters are `//` is removed.
+ *
+ * This lets template files (e.g. resume_pool.md) carry human-readable
+ * instructions without leaking them into the prompt.
+ *
+ * Example:
+ *   // This note is for the user only — never sent to the AI.
+ *   ## Experience
+ *   ...
+ */
+export function stripComments(text: string): string {
+  return text
+    .split('\n')
+    .filter(line => !line.trimStart().startsWith('//'))
+    .join('\n');
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -24,4 +24,8 @@ export default defineConfig({
   clean: true,
   // Type declarations are not needed for a CLI binary.
   dts: false,
+  // Copy static assets that are loaded at runtime via file:// URLs.
+  // tsup bundles all chunks to dist/ root, so __dirname resolves to dist/,
+  // meaning shell.html must live at dist/render/shell.html.
+  onSuccess: 'mkdir -p dist/render && cp src/service/impl/render/shell.html dist/render/shell.html',
 });


### PR DESCRIPTION
## Summary

- **Migrate build to tsup**: inlines `.md` files, copies `shell.html` to `dist/render/`, all deps external
- **Fix `wolf add` command** not registered in CLI
- **Fix null profile fields** omitted from `profile.toml` on init (null ↔ `""` round-trip via zod transform)
- **Add free-form immigration status** (`Other` option with freetext input in `wolf init`)
- **Add `stripComments()`** utility: strips `//` lines from resume pool before sending to AI
- **Rewrite resume_pool.md template**: correct section order, `//` comments throughout
- **Fix cover letter PDF** `Printing failed`: replaced bare `page.pdf()` with `fit()` — same code path as resume
- **Fix AI response truncation**: raised `max_tokens` 1024 → 4096
- **Fix missing resume sections**: rewrote `SYSTEM_PROMPT` with hard content limits (3 bullets/item, max 3 projects, 12–15 words/bullet) and removed conflicting word count target — Education, Skills, Publications, Languages now reliably appear
- **Save resume HTML** to `src/resume.html` for inspection alongside PDF

## Test plan
- [ ] `npm test` passes (61 tests)
- [ ] `npm run build` succeeds
- [ ] `wolf init` → profile.toml has all fields including nulls as `""`
- [ ] `wolf init` → selecting Other for immigration status prompts freetext
- [ ] `wolf tailor -j <id>` → resume PDF includes all sections (Experience, Projects, Education, Skills, Publications, Languages)
- [ ] `wolf tailor -j <id>` → cover letter PDF generates without error
- [ ] Both PDFs fit on one page