### PR TITLE
feat: services style sweep + pino-backed structured logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "dotenv": "^16.4.7",
         "drizzle-orm": "^0.36.4",
         "openai": "^6.34.0",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "smol-toml": "^1.6.0",
         "zod": "^4.3.6"
       },
@@ -26,6 +28,7 @@
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.13.10",
         "pdf-lib": "^1.17.1",
+        "pino-test": "^2.0.0",
         "playwright": "^1.59.1",
         "tsup": "^8.5.1",
         "typescript": "^5.8.2",
@@ -1004,6 +1007,12 @@
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
@@ -1907,6 +1916,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2117,6 +2135,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2231,6 +2255,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2705,10 +2738,22 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
@@ -2988,6 +3033,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hono": {
       "version": "4.12.8",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
@@ -3117,7 +3168,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
       "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3688,6 +3738,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3798,6 +3857,77 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/pino-test": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-test/-/pino-test-2.0.0.tgz",
+      "integrity": "sha512-quHvIgAFMzm1Jx05xaHYRk2fdE/UQifabYzwGkbp8nbr34zxKcFPZqP5foGvk0EoqtepctrRTiDELvESOiwgIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.2.0"
+      }
     },
     "node_modules/pirates": {
       "version": "4.0.7",
@@ -3976,6 +4106,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4013,6 +4159,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4088,6 +4240,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/require-from-string": {
@@ -4224,11 +4385,36 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -4450,6 +4636,15 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -4468,6 +4663,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -4500,6 +4704,18 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sucrase": {
@@ -4584,6 +4800,18 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.36.4",
     "openai": "^6.34.0",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "smol-toml": "^1.6.0",
     "zod": "^4.3.6"
   },
@@ -27,6 +29,7 @@
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.13.10",
     "pdf-lib": "^1.17.1",
+    "pino-test": "^2.0.0",
     "playwright": "^1.59.1",
     "tsup": "^8.5.1",
     "typescript": "^5.8.2",

--- a/src/application/__tests__/statusApplicationService.test.ts
+++ b/src/application/__tests__/statusApplicationService.test.ts
@@ -1,13 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { sink } from 'pino-test';
 import { StatusApplicationServiceImpl } from '../impl/statusApplicationServiceImpl.js';
-import { createSilentLogger, createMemorySink } from '../../utils/logger.js';
+import { createSilentLogger, setDefaultLogger } from '../../utils/logger.js';
 import type { StatusCounter } from '../statusApplicationService.js';
-import type { Logger } from '../../utils/logger.js';
 
 // StatusApplicationService is the single point that every module's status
 // contribution runs through. Tests here guard the registry pattern itself:
 // parallel fan-out, failure tolerance, and event logging on counter failure.
 describe('StatusApplicationServiceImpl', () => {
+  // Restore the silent default between tests in this file. One of the tests
+  // below installs a pino sink stream to capture a log event; without this
+  // afterEach, a later test in the same file would inherit that sink.
+  // Vitest isolates module state per FILE (isolate: true by default), so
+  // no setup is needed in test files that never mutate setDefaultLogger.
+  afterEach(() => setDefaultLogger(createSilentLogger()));
+
   // Helper: build a counter from a label and a value/function.
   function makeCounter(label: string, value: number | (() => Promise<number>)): StatusCounter {
     if (typeof value === 'function') return { label, count: value };
@@ -21,7 +29,7 @@ describe('StatusApplicationServiceImpl', () => {
       makeCounter('tailored', 3),
       makeCounter('applied', 1),
     ];
-    const svc = new StatusApplicationServiceImpl(counters, createSilentLogger());
+    const svc = new StatusApplicationServiceImpl(counters);
     const summary = await svc.getSummary();
     expect(summary.counters).toEqual([
       { label: 'tracked', count: 12 },
@@ -37,7 +45,6 @@ describe('StatusApplicationServiceImpl', () => {
     const fast = () => new Promise<number>((r) => setTimeout(() => r(2), 50));
     const svc = new StatusApplicationServiceImpl(
       [makeCounter('slow', slow), makeCounter('fast', fast)],
-      createSilentLogger(),
     );
     const t0 = Date.now();
     await svc.getSummary();
@@ -54,7 +61,7 @@ describe('StatusApplicationServiceImpl', () => {
       { label: 'broken', count: vi.fn().mockRejectedValue(new Error('db down')) },
       makeCounter('also-ok', 7),
     ];
-    const svc = new StatusApplicationServiceImpl(counters, createSilentLogger());
+    const svc = new StatusApplicationServiceImpl(counters);
     const summary = await svc.getSummary();
     expect(summary.counters).toEqual([
       { label: 'ok', count: 5 },
@@ -66,21 +73,32 @@ describe('StatusApplicationServiceImpl', () => {
   // Counter failures must be logged so the operator can investigate post-hoc
   // by reading data/logs/wolf.log.jsonl.
   it('logs a warn event when a counter fails', async () => {
-    const sink = createMemorySink();
-    const logger: Logger = {
-      debug: vi.fn(), info: vi.fn(),
-      warn: (msg, fields) => sink.write({ ts: '', level: 'warn', msg, ...(fields ?? {}) }),
-      error: vi.fn(),
-    };
+    // Install a pino instance whose output goes to a pino-test sink. The
+    // `log` facade re-reads _default on every call, so the next log.warn
+    // inside the service will hit THIS pino logger and land in the stream.
+    // We collect emitted events via the stream's 'data' listener so the
+    // assertions can live outside pino-test's deep-equality helper (which
+    // would have to match every emitted field exactly, including `time`).
+    const stream = sink();
+    setDefaultLogger(pino({ level: 'debug' }, stream));
+
+    const events: Record<string, unknown>[] = [];
+    stream.on('data', (line) => events.push(line));
+
     const counters: StatusCounter[] = [
       { label: 'broken', count: vi.fn().mockRejectedValue(new Error('boom')) },
     ];
-    const svc = new StatusApplicationServiceImpl(counters, logger);
+    const svc = new StatusApplicationServiceImpl(counters);
     await svc.getSummary();
-    expect(sink.events).toHaveLength(1);
-    expect(sink.events[0].msg).toBe('Status counter failed');
-    expect(sink.events[0].label).toBe('broken');
-    expect(sink.events[0].error).toBe('boom');
+
+    // Pino emits synchronously for a standard stream, so the event is
+    // already in `events` by the time await resolves.
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.msg).toBe('status.counter.failed');
+    expect(event.level).toBe(40); // pino numeric for `warn`
+    expect(event.label).toBe('broken');
+    expect(event.error).toBe('boom');
   });
 
   // Non-Error throws (string, undefined) must still produce a useful error
@@ -89,7 +107,7 @@ describe('StatusApplicationServiceImpl', () => {
     const counters: StatusCounter[] = [
       { label: 'bad', count: vi.fn().mockRejectedValue('bare string') },
     ];
-    const svc = new StatusApplicationServiceImpl(counters, createSilentLogger());
+    const svc = new StatusApplicationServiceImpl(counters);
     const summary = await svc.getSummary();
     expect(summary.counters[0].error).toBe('bare string');
   });
@@ -97,7 +115,7 @@ describe('StatusApplicationServiceImpl', () => {
   // Empty registry is a valid state (e.g. before any module has registered).
   // The summary should be empty but not throw.
   it('handles an empty counter registry', async () => {
-    const svc = new StatusApplicationServiceImpl([], createSilentLogger());
+    const svc = new StatusApplicationServiceImpl([]);
     const summary = await svc.getSummary();
     expect(summary.counters).toEqual([]);
   });

--- a/src/application/impl/statusApplicationServiceImpl.ts
+++ b/src/application/impl/statusApplicationServiceImpl.ts
@@ -1,4 +1,4 @@
-import type { Logger } from '../../utils/logger.js';
+import { log } from '../../utils/logger.js';
 import type {
   StatusApplicationService,
   StatusCount,
@@ -16,7 +16,6 @@ import type {
 export class StatusApplicationServiceImpl implements StatusApplicationService {
   constructor(
     private readonly counters: StatusCounter[],
-    private readonly logger: Logger,
   ) {}
 
   async getSummary(): Promise<StatusSummary> {
@@ -25,8 +24,11 @@ export class StatusApplicationServiceImpl implements StatusApplicationService {
         try {
           return { label, count: await count() };
         } catch (err) {
+          // Each failed counter logs a warn event (visible in data/logs/wolf.log.jsonl)
+          // and still returns count: 0 + an inline error so the dashboard
+          // keeps rendering. One broken counter must not kill the whole view.
           const message = err instanceof Error ? err.message : String(err);
-          this.logger.warn('Status counter failed', { label, error: message });
+          log.warn('status.counter.failed', { label, error: message });
           return { label, count: 0, error: message };
         }
       }),

--- a/src/application/impl/tailorApplicationServiceImpl.ts
+++ b/src/application/impl/tailorApplicationServiceImpl.ts
@@ -66,30 +66,45 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
   ) {}
 
   async tailor(options: TailorOptions): Promise<TailorResult> {
+    // Resolve job/profile/paths once; every step below works against this context.
     const ctx = await this.prepareContext(options);
+
+    // Make sure hint.md is in place before the analyst runs.
     await this.ensureHintFile(ctx.hintPath, options.hint);
 
     // Analyst first (serial) so both writers see the same brief.
     const brief = await this.runAnalysis(ctx);
 
-    // Resume + CL depend only on (brief + pool + jd), so they run in parallel.
-    // Skip the CL step if the caller passed --no-cover-letter.
+    // Resume + cover letter depend only on (brief + pool + jd), so they run
+    // in parallel. Skip the cover letter entirely when --no-cover-letter was
+    // passed — use a resolved null so the Promise.all shape stays the same.
     const writeCoverLetter = options.coverLetter !== false;
+    const coverLetterPromise = writeCoverLetter
+      ? this.runCoverLetter(ctx, brief)
+      : Promise.resolve(null);
     const [resumeStep, clStep] = await Promise.all([
       this.runResume(ctx, brief),
-      writeCoverLetter ? this.runCoverLetter(ctx, brief) : Promise.resolve(null),
+      coverLetterPromise,
     ]);
 
+    // Pre-compute the paths we'll hand to both the DB update and the result
+    // so the two sites can't drift.
+    const tailoredResumePdfPath = resumeStep.pdfPath;
+    const coverLetterHtmlPath = clStep?.htmlPath ?? null;
+    const coverLetterPdfPath = clStep?.pdfPath ?? null;
+
+    // Persist the generated paths on the Job row so downstream commands
+    // (wolf job list, wolf fill, wolf reach) can find the artifacts.
     await this.jobRepository.update(ctx.job.id, {
-      tailoredResumePdfPath: resumeStep.pdfPath,
-      coverLetterHtmlPath: clStep?.htmlPath ?? null,
-      coverLetterPdfPath:  clStep?.pdfPath  ?? null,
+      tailoredResumePdfPath,
+      coverLetterHtmlPath,
+      coverLetterPdfPath,
     });
 
     return {
-      tailoredPdfPath: resumeStep.pdfPath,
-      coverLetterHtmlPath: clStep?.htmlPath ?? null,
-      coverLetterPdfPath:  clStep?.pdfPath  ?? null,
+      tailoredPdfPath: tailoredResumePdfPath,
+      coverLetterHtmlPath,
+      coverLetterPdfPath,
       changes: [],
       matchScore: 0,
     };

--- a/src/application/impl/tailorApplicationServiceImpl.ts
+++ b/src/application/impl/tailorApplicationServiceImpl.ts
@@ -14,6 +14,7 @@ import type {
   UserProfile,
   Job,
 } from '../../types/index.js';
+import { log } from '../../utils/logger.js';
 import type { JobRepository } from '../../repository/jobRepository.js';
 import type { ProfileRepository } from '../../repository/profileRepository.js';
 import type { RenderService } from '../../service/renderService.js';
@@ -72,13 +73,25 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
     // Make sure hint.md is in place before the analyst runs.
     await this.ensureHintFile(ctx.hintPath, options.hint);
 
+    const writeCoverLetter = options.coverLetter !== false;
+    const pipelineStartedAt = Date.now();
+    log.info('tailor.pipeline.start', {
+      jobId: ctx.job.id,
+      profileId: ctx.profile.id,
+      coverLetterIncluded: writeCoverLetter,
+    });
+
     // Analyst first (serial) so both writers see the same brief.
+    const analyzeStartedAt = Date.now();
     const brief = await this.runAnalysis(ctx);
+    log.info('tailor.analyze.done', {
+      jobId: ctx.job.id,
+      durationMs: Date.now() - analyzeStartedAt,
+    });
 
     // Resume + cover letter depend only on (brief + pool + jd), so they run
     // in parallel. Skip the cover letter entirely when --no-cover-letter was
     // passed — use a resolved null so the Promise.all shape stays the same.
-    const writeCoverLetter = options.coverLetter !== false;
     const coverLetterPromise = writeCoverLetter
       ? this.runCoverLetter(ctx, brief)
       : Promise.resolve(null);
@@ -99,6 +112,13 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
       tailoredResumePdfPath,
       coverLetterHtmlPath,
       coverLetterPdfPath,
+    });
+
+    log.info('tailor.pipeline.done', {
+      jobId: ctx.job.id,
+      tailoredResumePdfPath,
+      coverLetterPdfPath,
+      durationMs: Date.now() - pipelineStartedAt,
     });
 
     return {
@@ -146,7 +166,12 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
       : this.defaultAiConfig;
 
     const job = await this.jobRepository.get(jobId);
-    if (!job) throw new Error(`Job not found: ${jobId}`);
+    if (!job) {
+      // Log before throwing so the failure leaves a structured breadcrumb
+      // in data/logs/wolf.log.jsonl even when the caller re-raises.
+      log.error('tailor.context.job_missing', { jobId });
+      throw new Error(`Job not found: ${jobId}`);
+    }
 
     const profile = profileId
       ? (await this.profileRepository.get(profileId)) ?? (await this.profileRepository.getDefault())
@@ -221,6 +246,12 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
     try {
       return await readFile(ctx.briefPath, 'utf-8');
     } catch {
+      // Log before throwing — users typically see the message only once the
+      // process exits, but the log file lets us debug recurring failures.
+      log.error('tailor.brief.read_failed', {
+        jobId: ctx.job.id,
+        briefPath: ctx.briefPath,
+      });
       throw new Error(
         `Tailoring brief not found at ${ctx.briefPath}. ` +
         `Run \`wolf tailor brief --job ${ctx.job.id}\` first.`,

--- a/src/cli/appContext.ts
+++ b/src/cli/appContext.ts
@@ -2,15 +2,21 @@
  * appContext.ts — Manual dependency injection container for wolf.
  *
  * Construction order:
- *   1. Open SQLite (real path or :memory: for tests)
- *   2. Wrap with Drizzle
- *   3. initializeSchema — creates tables if not exist
- *   4. Construct repositories (each receives DrizzleDb only)
- *   5. Construct services (each receives repository interfaces only)
- *   6. Construct application services (receive repositories + services)
+ *   1. Install the default logger (before any service is constructed)
+ *   2. Open SQLite (real path or :memory: for tests)
+ *   3. Wrap with Drizzle
+ *   4. initializeSchema — creates tables if not exist
+ *   5. Construct repositories (each receives DrizzleDb only)
+ *   6. Construct services (each receives repository interfaces only)
+ *   7. Construct application services (receive repositories + services)
  *
  * Swap any implementation by changing this file only.
  * No service or repository knows about this file.
+ *
+ * The logger is an exception to strict DI — services import `log` directly
+ * from `src/utils/logger.ts` rather than receiving it as a ctor arg. Keeps
+ * service signatures focused on their domain dependencies while still
+ * allowing tests to swap the default with `setDefaultLogger(memoryLogger)`.
  */
 
 import fs from 'node:fs';
@@ -31,15 +37,9 @@ import { TailoringBriefServiceImpl } from '../service/impl/tailoringBriefService
 import { StatusApplicationServiceImpl } from '../application/impl/statusApplicationServiceImpl.js';
 import { TailorApplicationServiceImpl } from '../application/impl/tailorApplicationServiceImpl.js';
 import { loadConfigSync } from '../utils/config.js';
-import {
-  createConsoleSink,
-  createFileSink,
-  createLogger,
-  createSilentLogger,
-} from '../utils/logger.js';
+import { createDefaultLogger, createSilentLogger, setDefaultLogger } from '../utils/logger.js';
 import { parseModelRef } from '../utils/parseModelRef.js';
 
-import type { Logger } from '../utils/logger.js';
 import type { JobRepository } from '../repository/jobRepository.js';
 import type { CompanyRepository } from '../repository/companyRepository.js';
 import type { BatchRepository } from '../repository/batchRepository.js';
@@ -73,15 +73,14 @@ export interface AppContext {
   statusApp: StatusApplicationService;
   // config
   defaultAiConfig: AiConfig;
-  // infrastructure
-  logger: Logger;
 }
 
 /**
  * Wires repositories, services, and application services around an open SQLite connection.
  * Extracted so both createAppContext() and createTestAppContext() share the same
  * construction logic, differing only in their SQLite instance, ProfileRepository,
- * workspaceDir, and defaultAiConfig.
+ * workspaceDir, and defaultAiConfig. The default logger must already be installed
+ * before calling this.
  */
 function wireContext(
   sqlite: BetterSqlite3.Database,
@@ -89,7 +88,6 @@ function wireContext(
   workspaceDir: string,
   defaultAiConfig: AiConfig,
   defaultCoverLetterTone: string,
-  logger: Logger,
 ): AppContext {
   const db = drizzle(sqlite);
   initializeSchema(db);
@@ -100,6 +98,10 @@ function wireContext(
   const jobRepo = new SqliteJobRepositoryImpl(db, companyRepo, workspaceDir);
   const batchRepo = new SqliteBatchRepositoryImpl(db);
 
+  // Services don't take `logger` through constructors — they import the `log`
+  // facade directly from src/utils/logger.ts. The default logger was installed
+  // via setDefaultLogger() in createAppContext / createTestAppContext before
+  // we got here.
   const batchService = new BatchServiceImpl(batchRepo, jobRepo);
   const renderService = new RenderServiceImpl();
   const rewriteService = new ResumeCoverLetterServiceImpl();
@@ -118,7 +120,7 @@ function wireContext(
     { label: 'tailored', count: () => jobRepo.countWithTailoredResume() },
     { label: 'applied',  count: async () => (await jobRepo.countByStatus()).applied },
   ];
-  const statusApp = new StatusApplicationServiceImpl(statusCounters, logger);
+  const statusApp = new StatusApplicationServiceImpl(statusCounters);
 
   return {
     jobRepository: jobRepo,
@@ -133,7 +135,6 @@ function wireContext(
     tailorApp,
     statusApp,
     defaultAiConfig,
-    logger,
   };
 }
 
@@ -150,6 +151,14 @@ export function createAppContext(): AppContext {
   const dataDir = path.join(workspaceDir, 'data');
   fs.mkdirSync(dataDir, { recursive: true });
 
+  // Install the real pino logger into the module slot BEFORE constructing
+  // any service. Pretty console output to stderr (or JSON when
+  // WOLF_LOG_FORMAT=json is set) and an always-on JSONL file sink under
+  // data/logs/wolf.log.jsonl. Level comes from WOLF_LOG (default info).
+  setDefaultLogger(createDefaultLogger({
+    filePath: path.join(dataDir, 'logs', 'wolf.log.jsonl'),
+  }));
+
   const dbPath = path.join(dataDir, 'wolf.sqlite');
   const sqlite = new BetterSqlite3(dbPath);
   const profileRepository = new FileProfileRepositoryImpl(workspaceDir);
@@ -159,34 +168,27 @@ export function createAppContext(): AppContext {
   const defaultAiConfig: AiConfig = parseModelRef(config.tailor.model);
   const defaultCoverLetterTone = config.tailor.defaultCoverLetterTone;
 
-  // Console to stderr + JSONL file sink under data/logs/. Level and console
-  // format come from WOLF_LOG / WOLF_LOG_FORMAT env vars (info + pretty by
-  // default). See src/utils/logger.ts.
-  const logger = createLogger({
-    sinks: [
-      createConsoleSink(process.env.WOLF_LOG_FORMAT === 'json' ? 'json' : 'pretty'),
-      createFileSink(path.join(dataDir, 'logs', 'wolf.log.jsonl')),
-    ],
-  });
-
   return wireContext(
-    sqlite, profileRepository, workspaceDir, defaultAiConfig, defaultCoverLetterTone, logger,
+    sqlite, profileRepository, workspaceDir, defaultAiConfig, defaultCoverLetterTone,
   );
 }
 
 /**
  * Test AppContext.
  *
- * Uses an in-memory SQLite database — no files are created.
- * Use in unit tests and integration tests that should not touch real files or
- * the network.
+ * Uses an in-memory SQLite database — no files are created. The default
+ * logger is reset to silent so test output stays clean.
  */
 export function createTestAppContext(): AppContext {
+  // Every test context starts silent. Individual tests that want to
+  // capture events override this with setDefaultLogger(memoryLogger) in
+  // their beforeEach, and restore it in afterEach.
+  setDefaultLogger(createSilentLogger());
+
   const sqlite = new BetterSqlite3(':memory:');
   const profileRepository = new InMemoryProfileRepositoryImpl();
   const defaultAiConfig: AiConfig = { provider: 'anthropic', model: 'claude-sonnet-4-6' };
   return wireContext(
     sqlite, profileRepository, '/tmp/wolf-test', defaultAiConfig, 'professional',
-    createSilentLogger(),
   );
 }

--- a/src/commands/env/index.ts
+++ b/src/commands/env/index.ts
@@ -218,6 +218,10 @@ const RC_FILES = [
   path.join(os.homedir(), '.profile'),
 ];
 
+// Matches a shell `export WOLF_...=...` line. Used both to find existing
+// entries (envClear preview) and to remove them (envClear action).
+const WOLF_EXPORT_LINE_RE = /^export\s+WOLF_/;
+
 /**
  * Removes all WOLF_* export lines from shell RC files and instructs the user
  * to reload their shell. On Windows (no RC files), prints manual instructions.
@@ -230,28 +234,18 @@ export async function envClear(): Promise<void> {
     return;
   }
 
-  const matches: { file: string; lines: string[] }[] = [];
-  for (const rc of RC_FILES) {
-    let content: string;
-    try {
-      content = await fs.readFile(rc, 'utf-8');
-    } catch {
-      continue;
-    }
-    const wolfLines = content
-      .split('\n')
-      .filter(l => /^export\s+WOLF_/.test(l.trim()));
-    if (wolfLines.length > 0) {
-      matches.push({ file: rc, lines: wolfLines });
-    }
-  }
+  // Scan every candidate RC file for `export WOLF_...` lines. Missing files
+  // are normal — a user may have only .zshrc or only .bashrc, never both.
+  const matches = await findWolfExportsAcrossRcFiles();
 
+  // Bail out with a helpful hint when nothing's there to clean up.
   if (matches.length === 0) {
     console.log('\nNo WOLF_* export lines found in shell RC files.\n');
     console.log(dim('If you set them another way (e.g. /etc/environment), remove them manually.\n'));
     return;
   }
 
+  // Show the user exactly which files and lines will be touched.
   console.log(`\n${bold('Found WOLF_* exports in:')}\n`);
   for (const { file, lines } of matches) {
     console.log(`  ${file}`);
@@ -261,6 +255,7 @@ export async function envClear(): Promise<void> {
   }
   console.log('');
 
+  // Destructive edit — require an explicit confirmation.
   const confirmed = await confirm({
     message: red('Remove all WOLF_* export lines from the files above?'),
     default: false,
@@ -270,13 +265,9 @@ export async function envClear(): Promise<void> {
     return;
   }
 
+  // Rewrite each file with matching lines removed.
   for (const { file } of matches) {
-    const content = await fs.readFile(file, 'utf-8');
-    const cleaned = content
-      .split('\n')
-      .filter(l => !/^export\s+WOLF_/.test(l.trim()))
-      .join('\n');
-    await fs.writeFile(file, cleaned, 'utf-8');
+    await removeWolfExportsFromRcFile(file);
     console.log(`  ${green('✓')} Cleaned ${file}`);
   }
 
@@ -286,4 +277,35 @@ ${bold('Done.')} Reload your shell to apply:
 
 Current session still has the keys in memory — open a new terminal to fully clear them.
 `);
+}
+
+// Returns the RC files that contain at least one `export WOLF_...` line,
+// with the matching lines for preview. Missing files are skipped.
+async function findWolfExportsAcrossRcFiles(): Promise<{ file: string; lines: string[] }[]> {
+  const matches: { file: string; lines: string[] }[] = [];
+  for (const rc of RC_FILES) {
+    let content: string;
+    try {
+      content = await fs.readFile(rc, 'utf-8');
+    } catch {
+      // File doesn't exist — not every user has every RC file.
+      continue;
+    }
+    const wolfLines = content.split('\n').filter((l) => WOLF_EXPORT_LINE_RE.test(l.trim()));
+    if (wolfLines.length > 0) {
+      matches.push({ file: rc, lines: wolfLines });
+    }
+  }
+  return matches;
+}
+
+// Rewrite `file` with every `export WOLF_...` line removed. Non-matching
+// lines (comments, non-wolf exports, blank lines) are preserved verbatim.
+async function removeWolfExportsFromRcFile(file: string): Promise<void> {
+  const content = await fs.readFile(file, 'utf-8');
+  const cleaned = content
+    .split('\n')
+    .filter((l) => !WOLF_EXPORT_LINE_RE.test(l.trim()))
+    .join('\n');
+  await fs.writeFile(file, cleaned, 'utf-8');
 }

--- a/src/repository/impl/sqliteJobRepositoryImpl.ts
+++ b/src/repository/impl/sqliteJobRepositoryImpl.ts
@@ -258,6 +258,10 @@ function buildConditionsWithSearch(q: JobQuery): SQL[] {
 
 type JobRow = typeof jobs.$inferSelect;
 
+// Drizzle's `$inferSelect` already types every nullable column as `T | null`,
+// so the rowToJob mapper can pass those fields through directly — no
+// defensive `?? null` needed. The insert-side mapper below still coalesces
+// to `undefined` because `$inferInsert` shapes optional columns that way.
 function rowToJob(row: JobRow): Job {
   return {
     id: row.id,
@@ -267,19 +271,19 @@ function rowToJob(row: JobRow): Job {
     source: row.source,
     location: row.location,
     remote: row.remote,
-    salary: row.salary ?? null,
+    salary: row.salary,
     workAuthorizationRequired: row.workAuthorizationRequired,
     clearanceRequired: row.clearanceRequired,
-    score: row.score ?? null,
-    scoreJustification: row.scoreJustification ?? null,
+    score: row.score,
+    scoreJustification: row.scoreJustification,
     status: row.status,
-    error: row.error ?? null,
-    appliedProfileId: row.appliedProfileId ?? null,
-    tailoredResumePdfPath: row.tailoredResumePdfPath ?? null,
-    coverLetterHtmlPath: row.coverLetterHtmlPath ?? null,
-    coverLetterPdfPath: row.coverLetterPdfPath ?? null,
-    screenshotPath: row.screenshotPath ?? null,
-    outreachDraftPath: row.outreachDraftPath ?? null,
+    error: row.error,
+    appliedProfileId: row.appliedProfileId,
+    tailoredResumePdfPath: row.tailoredResumePdfPath,
+    coverLetterHtmlPath: row.coverLetterHtmlPath,
+    coverLetterPdfPath: row.coverLetterPdfPath,
+    screenshotPath: row.screenshotPath,
+    outreachDraftPath: row.outreachDraftPath,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/src/service/__tests__/renderService.test.ts
+++ b/src/service/__tests__/renderService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RenderServiceImpl } from '../impl/renderServiceImpl.js';
 import { CannotFitError, CannotFillError } from '../impl/render/fit.js';
+import { createSilentLogger } from '../../utils/logger.js';
 import type { FitResult } from '../impl/render/fit.js';
 
 const FAKE_PDF = Buffer.from('fake-pdf-bytes');

--- a/src/service/__tests__/resumeCoverLetterService.test.ts
+++ b/src/service/__tests__/resumeCoverLetterService.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { sink } from 'pino-test';
 import { ResumeCoverLetterServiceImpl } from '../impl/resumeCoverLetterServiceImpl.js';
+import { createSilentLogger, setDefaultLogger } from '../../utils/logger.js';
 import type { UserProfile } from '../../types/index.js';
 import type { AiConfig } from '../../types/index.js';
 
@@ -38,6 +41,12 @@ const AI_CONFIG: AiConfig = { provider: 'anthropic', model: 'claude-sonnet-4-6' 
 
 describe('ResumeCoverLetterServiceImpl', () => {
   beforeEach(() => vi.clearAllMocks());
+  // Restore the silent default after each test because the event-capture
+  // tests below install a memory-sink logger. Without this, later tests
+  // in this file would inherit the memory sink. Vitest isolates module
+  // state per FILE (isolate: true by default), so unrelated test files
+  // don't need any logger setup at all.
+  afterEach(() => setDefaultLogger(createSilentLogger()));
 
   // Happy path: verify prompt includes brief, resume pool, and JD.
   it('calls aiClient with a prompt containing brief, resume pool and JD', async () => {
@@ -100,5 +109,59 @@ describe('ResumeCoverLetterServiceImpl', () => {
     await expect(
       svc.generateCoverLetter(RESUME_POOL, JD_TEXT, PROFILE, BRIEF, TONE, AI_CONFIG),
     ).rejects.toThrow('empty');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Logger retrofit — prove state transitions and errors are logged.
+  // Uses pino-test's `sink()` + a local 'data' listener to capture emitted
+  // events as parsed objects. Failure paths are the most valuable signals;
+  // they leave post-hoc breadcrumbs in data/logs/wolf.log.jsonl.
+  // ---------------------------------------------------------------------------
+
+  // Helper: install a pino sink and start collecting emitted events into an
+  // array so each test can assert on them after the service call returns.
+  function installCapture(): Record<string, unknown>[] {
+    const stream = sink();
+    setDefaultLogger(pino({ level: 'debug' }, stream));
+    const events: Record<string, unknown>[] = [];
+    stream.on('data', (line) => events.push(line));
+    return events;
+  }
+
+  it('emits ai.resume.start and ai.resume.done on the happy path', async () => {
+    vi.mocked(aiClient).mockResolvedValue('<h2>EXPERIENCE</h2>');
+    const events = installCapture();
+
+    const svc = new ResumeCoverLetterServiceImpl();
+    await svc.tailorResumeToHtml(RESUME_POOL, JD_TEXT, PROFILE, BRIEF, AI_CONFIG);
+
+    // Two events emitted: ai.resume.start (debug) then ai.resume.done (info).
+    // pino levels: debug=20, info=30.
+    expect(events).toHaveLength(2);
+    expect(events[0].msg).toBe('ai.resume.start');
+    expect(events[0].level).toBe(20);
+    expect(events[0].profileId).toBe(PROFILE.id);
+
+    expect(events[1].msg).toBe('ai.resume.done');
+    expect(events[1].level).toBe(30);
+    expect(events[1].profileId).toBe(PROFILE.id);
+    // The done event must carry the cost signal (durationMs is a number).
+    expect(typeof events[1].durationMs).toBe('number');
+  });
+
+  it('emits ai.resume.empty_response before rethrowing on empty AI output', async () => {
+    vi.mocked(aiClient).mockResolvedValue('');
+    const events = installCapture();
+
+    const svc = new ResumeCoverLetterServiceImpl();
+    await expect(svc.tailorResumeToHtml(RESUME_POOL, JD_TEXT, PROFILE, BRIEF, AI_CONFIG))
+      .rejects.toThrow('empty');
+
+    // Three events: start, done (even for empty response — validation
+    // happens after the AI call returns), then the error before the throw.
+    const errEvent = events.find((e) => e.msg === 'ai.resume.empty_response');
+    expect(errEvent).toBeDefined();
+    expect(errEvent?.level).toBe(50); // pino numeric for `error`
+    expect(errEvent?.profileId).toBe(PROFILE.id);
   });
 });

--- a/src/service/__tests__/tailoringBriefService.test.ts
+++ b/src/service/__tests__/tailoringBriefService.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { sink } from 'pino-test';
 import { TailoringBriefServiceImpl } from '../impl/tailoringBriefServiceImpl.js';
+import { createSilentLogger, setDefaultLogger } from '../../utils/logger.js';
 import type { UserProfile, AiConfig } from '../../types/index.js';
 
 // Mock aiClient so tests never touch the network.
@@ -21,6 +24,11 @@ const AI: AiConfig = { provider: 'anthropic', model: 'claude-sonnet-4-6' };
 
 describe('TailoringBriefService', () => {
   beforeEach(() => vi.clearAllMocks());
+  // Restore silent default after each test — the event-capture test below
+  // installs a memory-sink logger and without this afterEach, later tests
+  // in this file would inherit it. Vitest file-level isolation means
+  // unrelated test files need no logger setup at all.
+  afterEach(() => setDefaultLogger(createSilentLogger()));
 
   // Happy path: without a hint, the user prompt does not include a User Guidance section.
   // This guards against spurious "## User Guidance" showing up in the analyst prompt.
@@ -57,5 +65,30 @@ describe('TailoringBriefService', () => {
     vi.mocked(aiClient).mockResolvedValue('');
     const svc = new TailoringBriefServiceImpl();
     await expect(svc.analyze(POOL, JD, PROFILE, AI)).rejects.toThrow('empty brief');
+  });
+
+  // Logger retrofit — error-path capture. Proves that an empty brief from
+  // the AI produces a structured error event BEFORE the thrown exception
+  // bubbles out. This is the breadcrumb that lets us diagnose recurring
+  // failures from data/logs/wolf.log.jsonl without re-running the pipeline.
+  it('emits ai.brief.empty_response before rethrowing on empty AI output', async () => {
+    vi.mocked(aiClient).mockResolvedValue('');
+
+    // Install a pino-test sink and collect emitted events so we can find
+    // the error event by msg rather than by position (start/done fire
+    // first, then the error during validation).
+    const stream = sink();
+    setDefaultLogger(pino({ level: 'debug' }, stream));
+    const events: Record<string, unknown>[] = [];
+    stream.on('data', (line) => events.push(line));
+
+    const svc = new TailoringBriefServiceImpl();
+    await expect(svc.analyze(POOL, JD, PROFILE, AI)).rejects.toThrow('empty brief');
+
+    // Find the error event by message, assert its shape.
+    const errEvent = events.find((e) => e.msg === 'ai.brief.empty_response');
+    expect(errEvent).toBeDefined();
+    expect(errEvent?.level).toBe(50); // pino numeric for `error`
+    expect(errEvent?.profileId).toBe(PROFILE.id);
   });
 });

--- a/src/service/impl/renderServiceImpl.ts
+++ b/src/service/impl/renderServiceImpl.ts
@@ -1,24 +1,27 @@
 import { chromium } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { fit } from './render/fit.js';
+import { CannotFillError, CannotFitError, fit } from './render/fit.js';
+import { log } from '../../utils/logger.js';
 import type { Page } from 'playwright';
 import type { RenderService } from '../renderService.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SHELL_PATH = path.join(__dirname, 'render', 'shell.html');
 
+type RenderKind = 'resume' | 'cover';
+
 export class RenderServiceImpl implements RenderService {
   async renderPdf(htmlBody: string): Promise<Buffer> {
     // Resume rendering is a one-page fit job — identical browser lifecycle
     // and PDF path as the cover letter. Delegate to the shared helper.
-    return renderHtmlToPdf(htmlBody);
+    return renderHtmlToPdf(htmlBody, 'resume');
   }
 
   async renderCoverLetterPdf(htmlBody: string): Promise<Buffer> {
     // Cover letters are also one page, and `fit()` handles both overflow
     // and underflow, so they share the exact same code path.
-    return renderHtmlToPdf(htmlBody);
+    return renderHtmlToPdf(htmlBody, 'cover');
   }
 }
 
@@ -28,7 +31,10 @@ export class RenderServiceImpl implements RenderService {
 // both public entrypoints stay at the "one obvious line" level.
 // ---------------------------------------------------------------------------
 
-async function renderHtmlToPdf(htmlBody: string): Promise<Buffer> {
+async function renderHtmlToPdf(htmlBody: string, kind: RenderKind): Promise<Buffer> {
+  log.debug('render.start', { kind, contentLength: htmlBody.length });
+  const startedAt = Date.now();
+
   // Each render spawns a fresh browser — simpler state model than a pool,
   // and Playwright cold-start is only a few hundred ms.
   const browser = await chromium.launch();
@@ -44,12 +50,42 @@ async function renderHtmlToPdf(htmlBody: string): Promise<Buffer> {
     await injectHtmlIntoShell(page, htmlBody);
     await waitForFontsReady(page);
 
-    // Run the binary-search fit loop and return the resulting single-page PDF.
-    const result = await fit(page);
+    // Run the binary-search fit loop. On failure, log the fit-specific
+    // diagnostics before rethrowing so the caller only gets the one error.
+    const result = await runFitWithLogging(page, kind);
+    log.info('render.done', {
+      kind,
+      iterations: result.iterations,
+      finalFontSize: result.finalParams.fontSize,
+      pdfSizeBytes: result.pdf.length,
+      durationMs: Date.now() - startedAt,
+    });
     return result.pdf;
   } finally {
     // Always close the browser, even on fit/render errors.
     await browser.close();
+  }
+}
+
+// Runs fit() and translates its typed errors into warn-level log events
+// before rethrowing. Keeps renderHtmlToPdf readable by keeping the
+// error-translation logic out of its main flow.
+async function runFitWithLogging(page: Page, kind: RenderKind) {
+  try {
+    return await fit(page);
+  } catch (err) {
+    if (err instanceof CannotFitError) {
+      log.warn('render.fit.cannot_fit', {
+        kind,
+        iterations: err.lastAttempt.iterations,
+      });
+    } else if (err instanceof CannotFillError) {
+      log.warn('render.fit.cannot_fill', {
+        kind,
+        iterations: err.lastAttempt.iterations,
+      });
+    }
+    throw err;
   }
 }
 

--- a/src/service/impl/renderServiceImpl.ts
+++ b/src/service/impl/renderServiceImpl.ts
@@ -2,6 +2,7 @@ import { chromium } from 'playwright';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { fit } from './render/fit.js';
+import type { Page } from 'playwright';
 import type { RenderService } from '../renderService.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -9,50 +10,63 @@ const SHELL_PATH = path.join(__dirname, 'render', 'shell.html');
 
 export class RenderServiceImpl implements RenderService {
   async renderPdf(htmlBody: string): Promise<Buffer> {
-    const browser = await chromium.launch();
-    const page = await browser.newPage();
-    try {
-      await page.emulateMedia({ media: 'print' });
-      await page.goto('file://' + SHELL_PATH, { waitUntil: 'domcontentloaded' });
-      // Inject the HTML body into the shell's #resume-root container.
-      await page.evaluate((html: string) => {
-        const root = document.getElementById('resume-root');
-        if (!root) throw new Error('shell.html is missing #resume-root element');
-        root.innerHTML = html;
-      }, htmlBody);
-      // Wait for fonts to finish loading before measuring layout.
-      await page.evaluate(() =>
-        (document as unknown as { fonts: { ready: Promise<void> } }).fonts.ready
-      );
-      const result = await fit(page);
-      return result.pdf;
-    } finally {
-      await browser.close();
-    }
+    // Resume rendering is a one-page fit job — identical browser lifecycle
+    // and PDF path as the cover letter. Delegate to the shared helper.
+    return renderHtmlToPdf(htmlBody);
   }
 
   async renderCoverLetterPdf(htmlBody: string): Promise<Buffer> {
-    const browser = await chromium.launch();
-    const page = await browser.newPage();
-    try {
-      await page.emulateMedia({ media: 'print' });
-      await page.goto('file://' + SHELL_PATH, { waitUntil: 'domcontentloaded' });
-      // Inject the HTML body into the shell's #resume-root container.
-      await page.evaluate((html: string) => {
-        const root = document.getElementById('resume-root');
-        if (!root) throw new Error('shell.html is missing #resume-root element');
-        root.innerHTML = html;
-      }, htmlBody);
-      // Wait for fonts to finish loading before measuring layout.
-      await page.evaluate(() =>
-        (document as unknown as { fonts: { ready: Promise<void> } }).fonts.ready
-      );
-      // Reuse fit() — cover letters are one page and fit handles both overflow
-      // and underflow. This shares the exact same PDF code path as renderPdf().
-      const result = await fit(page);
-      return result.pdf;
-    } finally {
-      await browser.close();
-    }
+    // Cover letters are also one page, and `fit()` handles both overflow
+    // and underflow, so they share the exact same code path.
+    return renderHtmlToPdf(htmlBody);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Shared PDF rendering — launches Playwright, loads the shell, injects the
+// HTML body, runs the fit loop, and cleans up the browser. Extracted so
+// both public entrypoints stay at the "one obvious line" level.
+// ---------------------------------------------------------------------------
+
+async function renderHtmlToPdf(htmlBody: string): Promise<Buffer> {
+  // Each render spawns a fresh browser — simpler state model than a pool,
+  // and Playwright cold-start is only a few hundred ms.
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  try {
+    // Emulate print media so CSS @media print rules take effect.
+    await page.emulateMedia({ media: 'print' });
+
+    // Load the static shell (styles + layout scaffold + #resume-root placeholder).
+    await page.goto('file://' + SHELL_PATH, { waitUntil: 'domcontentloaded' });
+
+    // Inject the rendered body into the shell and wait for fonts.
+    await injectHtmlIntoShell(page, htmlBody);
+    await waitForFontsReady(page);
+
+    // Run the binary-search fit loop and return the resulting single-page PDF.
+    const result = await fit(page);
+    return result.pdf;
+  } finally {
+    // Always close the browser, even on fit/render errors.
+    await browser.close();
+  }
+}
+
+// Place the caller-provided HTML into the shell's root container. Throws
+// with a clear message if the shell template is malformed.
+async function injectHtmlIntoShell(page: Page, htmlBody: string): Promise<void> {
+  await page.evaluate((html: string) => {
+    const root = document.getElementById('resume-root');
+    if (!root) throw new Error('shell.html is missing #resume-root element');
+    root.innerHTML = html;
+  }, htmlBody);
+}
+
+// Wait for webfont loading before measuring page layout — otherwise the
+// fit loop measures a layout with fallback fonts and picks wrong params.
+async function waitForFontsReady(page: Page): Promise<void> {
+  await page.evaluate(() =>
+    (document as unknown as { fonts: { ready: Promise<void> } }).fonts.ready,
+  );
 }

--- a/src/service/impl/resumeCoverLetterServiceImpl.ts
+++ b/src/service/impl/resumeCoverLetterServiceImpl.ts
@@ -13,35 +13,21 @@ export class ResumeCoverLetterServiceImpl implements ResumeCoverLetterService {
     brief: string,
     aiConfig: AiConfig,
   ): Promise<string> {
-    const urls = [profile.firstUrl, profile.secondUrl, profile.thirdUrl]
-      .filter(Boolean)
-      .join(' · ');
+    // Build the prompt sections so each block reads as its own unit.
+    const contactSection = buildContactSection(profile);
+    const briefSection = buildBriefSection(brief);
+    const poolSection = buildResumePoolSection(resumePool);
+    const jdSection = buildJdSection(jdText);
+    const instruction = "Produce the tailored resume HTML body now, following the brief's selections.";
 
-    const userPrompt = `## Candidate Contact Info
-Name: ${profile.name}
-Email: ${profile.email}
-Phone: ${profile.phone}
-URLs: ${urls || 'none'}
+    const userPrompt = [contactSection, briefSection, poolSection, jdSection, instruction].join('\n\n');
 
-## Tailoring Brief
-${brief}
-
-## Resume Pool
-${stripComments(resumePool)}
-
-## Job Description
-${jdText}
-
-Produce the tailored resume HTML body now, following the brief's selections.`;
-
-    const text = await aiClient(userPrompt, SYSTEM_PROMPT, {
+    // Send to the configured AI provider and require a non-empty response.
+    const raw = await aiClient(userPrompt, SYSTEM_PROMPT, {
       provider: aiConfig.provider,
       model: aiConfig.model,
     });
-
-    const trimmed = text.trim();
-    if (!trimmed) throw new Error('ResumeCoverLetterService: AI returned an empty response');
-    return trimmed;
+    return validateNonEmptyResponse(raw, 'resume');
   }
 
   async generateCoverLetter(
@@ -52,35 +38,73 @@ Produce the tailored resume HTML body now, following the brief's selections.`;
     tone: string,
     aiConfig: AiConfig,
   ): Promise<string> {
-    const urls = [profile.firstUrl, profile.secondUrl, profile.thirdUrl]
-      .filter(Boolean)
-      .join(' · ');
+    // Same prompt shape as the resume path, plus a Tone line in the contact block.
+    const contactSection = buildContactSection(profile, tone);
+    const briefSection = buildBriefSection(brief);
+    const poolSection = buildResumePoolSection(resumePool);
+    const jdSection = buildJdSection(jdText);
+    const instruction = "Produce the cover letter HTML body now, following the brief's angle and themes.";
 
-    const userPrompt = `## Candidate Contact Info
-Name: ${profile.name}
-Email: ${profile.email}
-Phone: ${profile.phone}
-URLs: ${urls || 'none'}
-Tone: ${tone}
+    const userPrompt = [contactSection, briefSection, poolSection, jdSection, instruction].join('\n\n');
 
-## Tailoring Brief
-${brief}
-
-## Resume Pool
-${stripComments(resumePool)}
-
-## Job Description
-${jdText}
-
-Produce the cover letter HTML body now, following the brief's angle and themes.`;
-
-    const text = await aiClient(userPrompt, COVER_LETTER_SYSTEM_PROMPT, {
+    // Send to the configured AI provider and require a non-empty response.
+    const raw = await aiClient(userPrompt, COVER_LETTER_SYSTEM_PROMPT, {
       provider: aiConfig.provider,
       model: aiConfig.model,
     });
-
-    const trimmed = text.trim();
-    if (!trimmed) throw new Error('ResumeCoverLetterService: AI returned an empty cover letter response');
-    return trimmed;
+    return validateNonEmptyResponse(raw, 'cover letter');
   }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-section builders — extracted so each section reads as its own block
+// in the public methods above. All section bodies are plain markdown.
+// ---------------------------------------------------------------------------
+
+// Join the profile's optional URLs with a separator, returning "none" when
+// the user has set none of the three.
+function formatProfileUrls(profile: UserProfile): string {
+  const candidateUrls = [profile.firstUrl, profile.secondUrl, profile.thirdUrl];
+  const presentUrls = candidateUrls.filter((u): u is string => Boolean(u));
+  if (presentUrls.length === 0) return 'none';
+  return presentUrls.join(' · ');
+}
+
+// Contact block — same shape for both resume and cover letter. The optional
+// `tone` argument adds the cover-letter-only Tone line.
+function buildContactSection(profile: UserProfile, tone?: string): string {
+  const urls = formatProfileUrls(profile);
+  const lines = [
+    '## Candidate Contact Info',
+    `Name: ${profile.name}`,
+    `Email: ${profile.email}`,
+    `Phone: ${profile.phone}`,
+    `URLs: ${urls}`,
+  ];
+  if (tone !== undefined) lines.push(`Tone: ${tone}`);
+  return lines.join('\n');
+}
+
+function buildBriefSection(brief: string): string {
+  return `## Tailoring Brief\n${brief}`;
+}
+
+// Strip `//` comment lines from the pool before the AI sees them — those are
+// human-only notes and would confuse the AI's selection of content.
+function buildResumePoolSection(resumePool: string): string {
+  return `## Resume Pool\n${stripComments(resumePool)}`;
+}
+
+function buildJdSection(jdText: string): string {
+  return `## Job Description\n${jdText}`;
+}
+
+// Trim the AI response and reject empty output. Centralizing here keeps the
+// thrown message consistent across both callers.
+function validateNonEmptyResponse(raw: string, what: 'resume' | 'cover letter'): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`ResumeCoverLetterService: AI returned an empty ${what} response`);
+  }
+  return trimmed;
 }

--- a/src/service/impl/resumeCoverLetterServiceImpl.ts
+++ b/src/service/impl/resumeCoverLetterServiceImpl.ts
@@ -1,4 +1,5 @@
 import { aiClient } from '../../utils/ai/index.js';
+import { log } from '../../utils/logger.js';
 import { stripComments } from '../../utils/stripComments.js';
 import SYSTEM_PROMPT from './prompts/tailor-system.md';
 import COVER_LETTER_SYSTEM_PROMPT from './prompts/cover-letter-system.md';
@@ -22,12 +23,27 @@ export class ResumeCoverLetterServiceImpl implements ResumeCoverLetterService {
 
     const userPrompt = [contactSection, briefSection, poolSection, jdSection, instruction].join('\n\n');
 
-    // Send to the configured AI provider and require a non-empty response.
+    // Bracket the AI call with start/done events so cost signals (durationMs,
+    // responseLength) end up in data/logs/wolf.log.jsonl for post-hoc analysis.
+    log.debug('ai.resume.start', {
+      profileId: profile.id,
+      provider: aiConfig.provider,
+      model: aiConfig.model,
+    });
+    const startedAt = Date.now();
     const raw = await aiClient(userPrompt, SYSTEM_PROMPT, {
       provider: aiConfig.provider,
       model: aiConfig.model,
     });
-    return validateNonEmptyResponse(raw, 'resume');
+    log.info('ai.resume.done', {
+      profileId: profile.id,
+      durationMs: Date.now() - startedAt,
+      responseLength: raw.length,
+    });
+
+    // Validate-or-throw. Log before the throw so the failure leaves a
+    // structured breadcrumb even when the process exits.
+    return validateAndLogOrThrow(raw, 'resume', profile.id);
   }
 
   async generateCoverLetter(
@@ -47,12 +63,41 @@ export class ResumeCoverLetterServiceImpl implements ResumeCoverLetterService {
 
     const userPrompt = [contactSection, briefSection, poolSection, jdSection, instruction].join('\n\n');
 
-    // Send to the configured AI provider and require a non-empty response.
+    // Bracket the AI call with start/done events — same shape as the resume path.
+    log.debug('ai.cover.start', {
+      profileId: profile.id,
+      provider: aiConfig.provider,
+      model: aiConfig.model,
+    });
+    const startedAt = Date.now();
     const raw = await aiClient(userPrompt, COVER_LETTER_SYSTEM_PROMPT, {
       provider: aiConfig.provider,
       model: aiConfig.model,
     });
-    return validateNonEmptyResponse(raw, 'cover letter');
+    log.info('ai.cover.done', {
+      profileId: profile.id,
+      durationMs: Date.now() - startedAt,
+      responseLength: raw.length,
+    });
+
+    return validateAndLogOrThrow(raw, 'cover letter', profile.id);
+  }
+}
+
+// Validate + log-on-failure wrapper. Produces the same thrown Error as
+// the pure validateNonEmptyResponse helper, but emits a structured
+// `error` event first so the failure is visible in the log file.
+function validateAndLogOrThrow(
+  raw: string,
+  what: 'resume' | 'cover letter',
+  profileId: string,
+): string {
+  try {
+    return validateNonEmptyResponse(raw, what);
+  } catch (err) {
+    const eventName = what === 'resume' ? 'ai.resume.empty_response' : 'ai.cover.empty_response';
+    log.error(eventName, { profileId });
+    throw err;
   }
 }
 

--- a/src/service/impl/tailoringBriefServiceImpl.ts
+++ b/src/service/impl/tailoringBriefServiceImpl.ts
@@ -12,31 +12,65 @@ export class TailoringBriefServiceImpl implements TailoringBriefService {
     aiConfig: AiConfig,
     hint?: string,
   ): Promise<string> {
-    // User Guidance section only appears when hint is non-empty — keeps the prompt
-    // clean when no guidance was provided.
-    const guidanceSection = hint?.trim()
-      ? `\n\n## User Guidance (authoritative - align the brief to this)\n${hint.trim()}`
-      : '';
+    // Build the prompt sections so each block reads as its own unit.
+    const candidateSection = buildCandidateSection(profile);
+    const poolSection = buildResumePoolSection(resumePool);
+    const jdSection = buildJdSection(jdText);
+    const guidanceSection = buildGuidanceSection(hint);
+    const instruction = 'Produce the tailoring brief now.';
 
-    const userPrompt = `## Candidate
-Name: ${profile.name}
-Target roles: ${profile.targetRoles.join(', ') || 'unspecified'}
+    // Guidance is omitted entirely when absent — no blank `## User Guidance`
+    // heading reaches the AI. Filter out empty sections before joining.
+    const sections = [candidateSection, poolSection, jdSection, guidanceSection, instruction];
+    const userPrompt = sections.filter((s) => s.length > 0).join('\n\n');
 
-## Resume Pool
-${stripComments(resumePool)}
-
-## Job Description
-${jdText}${guidanceSection}
-
-Produce the tailoring brief now.`;
-
-    const text = await aiClient(userPrompt, ANALYST_SYSTEM_PROMPT, {
+    // Send to the configured AI provider and require a non-empty response.
+    const raw = await aiClient(userPrompt, ANALYST_SYSTEM_PROMPT, {
       provider: aiConfig.provider,
       model: aiConfig.model,
     });
-
-    const trimmed = text.trim();
-    if (!trimmed) throw new Error('TailoringBriefService: AI returned an empty brief');
-    return trimmed;
+    return validateNonEmptyBrief(raw);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-section builders — same shape as the sibling ResumeCoverLetter
+// service. Each builder returns a complete, stand-alone section.
+// ---------------------------------------------------------------------------
+
+function buildCandidateSection(profile: UserProfile): string {
+  // targetRoles can be empty for a brand-new profile; default to a sentinel
+  // so the AI gets a readable value instead of an empty list.
+  const targetRoles = profile.targetRoles.join(', ') || 'unspecified';
+  return [
+    '## Candidate',
+    `Name: ${profile.name}`,
+    `Target roles: ${targetRoles}`,
+  ].join('\n');
+}
+
+// Strip `//` comment lines from the pool before the AI sees them.
+function buildResumePoolSection(resumePool: string): string {
+  return `## Resume Pool\n${stripComments(resumePool)}`;
+}
+
+function buildJdSection(jdText: string): string {
+  return `## Job Description\n${jdText}`;
+}
+
+// Optional user-authored guidance block. Returns an empty string when no
+// hint was provided, so the caller can filter it out of the final prompt.
+function buildGuidanceSection(hint: string | undefined): string {
+  const trimmed = hint?.trim();
+  if (trimmed === undefined || trimmed.length === 0) return '';
+  return `## User Guidance (authoritative - align the brief to this)\n${trimmed}`;
+}
+
+// Trim the AI response and reject empty output.
+function validateNonEmptyBrief(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new Error('TailoringBriefService: AI returned an empty brief');
+  }
+  return trimmed;
 }

--- a/src/service/impl/tailoringBriefServiceImpl.ts
+++ b/src/service/impl/tailoringBriefServiceImpl.ts
@@ -1,4 +1,5 @@
 import { aiClient } from '../../utils/ai/index.js';
+import { log } from '../../utils/logger.js';
 import { stripComments } from '../../utils/stripComments.js';
 import ANALYST_SYSTEM_PROMPT from './prompts/analyst-system.md';
 import type { TailoringBriefService } from '../tailoringBriefService.js';
@@ -24,12 +25,33 @@ export class TailoringBriefServiceImpl implements TailoringBriefService {
     const sections = [candidateSection, poolSection, jdSection, guidanceSection, instruction];
     const userPrompt = sections.filter((s) => s.length > 0).join('\n\n');
 
-    // Send to the configured AI provider and require a non-empty response.
+    // Bracket the AI call with start/done events. `hintProvided` captures
+    // whether the analyst was steered — useful when debugging brief quality.
+    log.debug('ai.brief.start', {
+      profileId: profile.id,
+      provider: aiConfig.provider,
+      model: aiConfig.model,
+      hintProvided: guidanceSection.length > 0,
+    });
+    const startedAt = Date.now();
     const raw = await aiClient(userPrompt, ANALYST_SYSTEM_PROMPT, {
       provider: aiConfig.provider,
       model: aiConfig.model,
     });
-    return validateNonEmptyBrief(raw);
+    log.info('ai.brief.done', {
+      profileId: profile.id,
+      durationMs: Date.now() - startedAt,
+      responseLength: raw.length,
+    });
+
+    // Validate-or-throw. Log before the throw so the failure leaves a
+    // structured breadcrumb in data/logs/wolf.log.jsonl.
+    try {
+      return validateNonEmptyBrief(raw);
+    } catch (err) {
+      log.error('ai.brief.empty_response', { profileId: profile.id });
+      throw err;
+    }
   }
 }
 

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,249 +1,166 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { afterEach, describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { sink } from 'pino-test';
 import {
-  createConsoleSink,
-  createFileSink,
-  createLogger,
-  createMemorySink,
+  createDefaultLogger,
   createSilentLogger,
-  type Logger,
+  getLogger,
+  log,
+  setDefaultLogger,
 } from '../logger.js';
 
-// The logger is pure infrastructure — every assertion here guards a behavior
-// that downstream services will rely on (level filtering, structured fields,
-// sink fan-out, file persistence). Breakage here breaks observability for
-// every long-running flow in wolf (tailor, hunt, score).
-describe('logger', () => {
-  describe('level filtering', () => {
-    // Default level is info → debug events must be silently dropped.
-    it('drops debug events at default level', () => {
-      const sink = createMemorySink();
-      const logger = createLogger({ sinks: [sink] });
-      logger.debug('should not appear');
-      expect(sink.events).toHaveLength(0);
-    });
+// The logger wraps pino with an ergonomic facade. Tests here confirm
+// the critical contract: facade call -> pino emission -> capture stream.
+// Pino's own internals aren't re-tested; we trust the library.
+describe('logger facade', () => {
+  // Restore silence between tests so one test's capture stream doesn't
+  // leak into another test's expectations.
+  afterEach(() => setDefaultLogger(createSilentLogger()));
 
-    // At debug level, every level must pass through.
-    it('emits all levels when threshold is debug', () => {
-      const sink = createMemorySink();
-      const logger = createLogger({ level: 'debug', sinks: [sink] });
-      logger.debug('d');
-      logger.info('i');
-      logger.warn('w');
-      logger.error('e');
-      expect(sink.events.map(ev => ev.level)).toEqual(['debug', 'info', 'warn', 'error']);
-    });
+  // Helper: install a pino-test sink as the default logger and collect
+  // every emitted line into a local array.
+  function installCapture(level: 'debug' | 'info' | 'warn' | 'error' = 'debug') {
+    const stream = sink();
+    setDefaultLogger(pino({ level }, stream));
+    const events: Record<string, unknown>[] = [];
+    stream.on('data', (line) => events.push(line));
+    return events;
+  }
 
-    // At warn level, debug and info must be dropped but warn/error pass.
-    it('only emits warn and error when threshold is warn', () => {
-      const sink = createMemorySink();
-      const logger = createLogger({ level: 'warn', sinks: [sink] });
-      logger.debug('d');
-      logger.info('i');
-      logger.warn('w');
-      logger.error('e');
-      expect(sink.events.map(ev => ev.level)).toEqual(['warn', 'error']);
-    });
+  // The facade must route method calls to the currently-installed pino
+  // instance — not a reference captured at import time.
+  it('emits the message through the currently-installed pino instance', () => {
+    const events = installCapture();
+    log.info('test.event');
+    expect(events).toHaveLength(1);
+    expect(events[0].msg).toBe('test.event');
+    expect(events[0].level).toBe(30); // pino numeric for info
   });
 
-  describe('event shape', () => {
-    // Every event must carry a structured shape: ts + level + msg + any
-    // user-provided fields flattened onto the root object.
-    it('produces events with ts, level, msg, and flattened fields', () => {
-      const sink = createMemorySink();
-      const logger = createLogger({ sinks: [sink] });
-      logger.info('tailoring resume', { jobId: 'abc123', profileId: 'default' });
-      expect(sink.events).toHaveLength(1);
-      const ev = sink.events[0];
-      expect(ev.level).toBe('info');
-      expect(ev.msg).toBe('tailoring resume');
-      expect(ev.jobId).toBe('abc123');
-      expect(ev.profileId).toBe('default');
-      // ts must be a valid ISO-8601 string so log aggregators can parse it.
-      expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-    });
-
-    // A message without fields should still emit a valid event — the fields
-    // argument is optional and most log calls omit it.
-    it('handles events with no fields', () => {
-      const sink = createMemorySink();
-      const logger = createLogger({ sinks: [sink] });
-      logger.info('no fields here');
-      expect(sink.events[0].msg).toBe('no fields here');
-    });
+  // Fields argument must be merged onto the emitted event.
+  it('attaches structured fields when provided', () => {
+    const events = installCapture();
+    log.warn('test.warn', { jobId: 'abc', attempt: 2 });
+    expect(events[0].msg).toBe('test.warn');
+    expect(events[0].level).toBe(40); // warn
+    expect(events[0].jobId).toBe('abc');
+    expect(events[0].attempt).toBe(2);
   });
 
-  describe('sink fan-out', () => {
-    // Every configured sink must receive every event that passes the level
-    // filter. Fan-out is how we support console + file at the same time.
-    it('writes the same event to every sink', () => {
-      const a = createMemorySink();
-      const b = createMemorySink();
-      const logger = createLogger({ sinks: [a, b] });
-      logger.info('ping');
-      expect(a.events).toHaveLength(1);
-      expect(b.events).toHaveLength(1);
-      expect(a.events[0].msg).toBe(b.events[0].msg);
-    });
+  // Each level must round-trip to pino's corresponding numeric level.
+  // Guards against a typo in the facade that routes warn to info, etc.
+  it('routes each facade level to the matching pino level', () => {
+    const events = installCapture('debug');
+    log.debug('d');
+    log.info('i');
+    log.warn('w');
+    log.error('e');
+    // Pino numerics: trace=10, debug=20, info=30, warn=40, error=50, fatal=60.
+    expect(events.map((e) => e.level)).toEqual([20, 30, 40, 50]);
   });
 
-  describe('createConsoleSink', () => {
-    let stderrSpy: ReturnType<typeof vi.spyOn>;
-
-    beforeEach(() => {
-      // Hijack stderr so we can assert exactly what the sink wrote.
-      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    });
-    afterEach(() => {
-      stderrSpy.mockRestore();
-    });
-
-    // Logger output belongs on stderr — stdout is reserved for command
-    // deliverables so `wolf job ls | grep open` stays unpolluted.
-    it('writes to stderr, not stdout', () => {
-      const sink = createConsoleSink('json');
-      sink.write({ ts: 'T', level: 'info', msg: 'hi' });
-      expect(stderrSpy).toHaveBeenCalledTimes(1);
-    });
-
-    // Pretty mode: single-line human format with a level glyph and fields
-    // rendered as key=value pairs.
-    it('renders pretty format with glyph + message + fields', () => {
-      const sink = createConsoleSink('pretty');
-      sink.write({ ts: 'T', level: 'warn', msg: 'rate-limited', attempt: 2 });
-      const written = String(stderrSpy.mock.calls[0][0]);
-      expect(written).toContain('⚠ rate-limited');
-      expect(written).toContain('attempt=2');
-      expect(written.endsWith('\n')).toBe(true);
-    });
-
-    // JSON mode: one line of parseable JSON per event.
-    it('renders json format as one JSON object per line', () => {
-      const sink = createConsoleSink('json');
-      sink.write({ ts: '2026-04-18T00:00:00.000Z', level: 'error', msg: 'boom', code: 1 });
-      const written = String(stderrSpy.mock.calls[0][0]);
-      expect(written.endsWith('\n')).toBe(true);
-      const parsed = JSON.parse(written.trim());
-      expect(parsed).toEqual({
-        ts: '2026-04-18T00:00:00.000Z',
-        level: 'error',
-        msg: 'boom',
-        code: 1,
-      });
-    });
-
-    // Object-typed fields must be JSON-stringified in pretty mode, otherwise
-    // they render as useless "[object Object]".
-    it('stringifies nested object values in pretty mode', () => {
-      const sink = createConsoleSink('pretty');
-      sink.write({ ts: 'T', level: 'info', msg: 'nested', meta: { a: 1, b: 'x' } });
-      const written = String(stderrSpy.mock.calls[0][0]);
-      expect(written).toContain('meta={"a":1,"b":"x"}');
-    });
-  });
-
-  describe('createFileSink', () => {
-    let tmpDir: string;
-    beforeEach(() => {
-      // Real tmp dir so we can also verify auto-mkdir of nested parents.
-      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wolf-logger-'));
-    });
-    afterEach(() => {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    });
-
-    // Each write must append one newline-delimited JSON object — the JSONL
-    // shape that every log aggregator and every unix tool understands.
-    it('appends one JSON event per line', () => {
-      const filePath = path.join(tmpDir, 'wolf.log.jsonl');
-      const sink = createFileSink(filePath);
-      sink.write({ ts: 'T1', level: 'info', msg: 'first', n: 1 });
-      sink.write({ ts: 'T2', level: 'warn', msg: 'second', n: 2 });
-      const content = fs.readFileSync(filePath, 'utf8');
-      const lines = content.trim().split('\n');
-      expect(lines).toHaveLength(2);
-      expect(JSON.parse(lines[0])).toEqual({ ts: 'T1', level: 'info', msg: 'first', n: 1 });
-      expect(JSON.parse(lines[1])).toEqual({ ts: 'T2', level: 'warn', msg: 'second', n: 2 });
-    });
-
-    // If the parent directory doesn't exist yet (fresh workspace), the sink
-    // must create it rather than erroring on the first write.
-    it('creates the parent directory if missing', () => {
-      const filePath = path.join(tmpDir, 'nested', 'dir', 'wolf.log.jsonl');
-      const sink = createFileSink(filePath);
-      sink.write({ ts: 'T', level: 'info', msg: 'hi' });
-      expect(fs.existsSync(filePath)).toBe(true);
-    });
-  });
-
-  describe('createLogger defaults', () => {
-    const savedEnv = { ...process.env };
-    afterEach(() => {
-      // Restore any env vars we mutated so one test can't leak into another.
-      process.env = { ...savedEnv };
-    });
-
-    // When WOLF_LOG is not set, the logger must default to info — otherwise
-    // users would either see every debug line or nothing at all.
-    it('defaults to info level when WOLF_LOG is unset', () => {
-      delete process.env.WOLF_LOG;
-      const sink = createMemorySink();
-      const logger = createLogger({ sinks: [sink] });
-      logger.debug('drop me');
-      logger.info('keep me');
-      expect(sink.events).toHaveLength(1);
-      expect(sink.events[0].msg).toBe('keep me');
-    });
-
-    // WOLF_LOG=debug must lower the threshold without requiring a code change.
-    it('picks up WOLF_LOG=debug from the environment', () => {
-      process.env.WOLF_LOG = 'debug';
-      const sink = createMemorySink();
-      const logger = createLogger({ sinks: [sink] });
-      logger.debug('now visible');
-      expect(sink.events).toHaveLength(1);
-    });
-
-    // Unknown WOLF_LOG values must fall back to info rather than crash — the
-    // env var is user-facing and a typo shouldn't break the CLI.
-    it('falls back to info when WOLF_LOG is an unknown value', () => {
-      process.env.WOLF_LOG = 'trace';
-      const sink = createMemorySink();
-      const logger = createLogger({ sinks: [sink] });
-      logger.debug('still dropped');
-      logger.info('kept');
-      expect(sink.events.map(e => e.msg)).toEqual(['kept']);
-    });
-
-    // Explicit option must override the env var so callers (AppContext,
-    // tests) can fully control the logger regardless of the environment.
-    it('explicit level option overrides WOLF_LOG', () => {
-      process.env.WOLF_LOG = 'error';
-      const sink = createMemorySink();
-      const logger = createLogger({ level: 'info', sinks: [sink] });
-      logger.info('kept');
-      expect(sink.events).toHaveLength(1);
-    });
-  });
-
-  describe('createSilentLogger', () => {
-    // Must never emit anything — useful for test AppContexts that don't want
-    // log noise in the test runner output.
-    it('discards every event', () => {
-      const spy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
-      try {
-        const logger: Logger = createSilentLogger();
-        logger.debug('x');
-        logger.info('x');
-        logger.warn('x');
-        logger.error('x');
-        expect(spy).not.toHaveBeenCalled();
-      } finally {
-        spy.mockRestore();
-      }
-    });
+  // getLogger must return the instance last installed, so tests that need
+  // the raw pino instance (for constructing child loggers, for example)
+  // can reach it.
+  it('getLogger returns the current default', () => {
+    const logger = pino({ level: 'silent' });
+    setDefaultLogger(logger);
+    expect(getLogger()).toBe(logger);
   });
 });
+
+// Silent logger is the Null Object of the logging world — every level
+// discards its input. Useful as the module's default and as a test-safe
+// fallback when a real logger isn't appropriate.
+describe('createSilentLogger', () => {
+  it('returns a pino logger with level set to silent', () => {
+    const logger = createSilentLogger();
+    // pino's `silent` level string maps to the numeric value that disables
+    // every emission. Calling .info(...) is a no-op.
+    expect(logger.level).toBe('silent');
+  });
+});
+
+// createDefaultLogger is the production-path builder. In tests
+// (NODE_ENV=test), it must still produce a silent logger so calling it
+// in a test context can never leak output to the real terminal or disk.
+describe('createDefaultLogger', () => {
+  it('returns a silent logger when NODE_ENV=test', () => {
+    // Vitest sets NODE_ENV=test automatically, so this covers the test-env path.
+    const logger = createDefaultLogger();
+    expect(logger.level).toBe('silent');
+  });
+
+  it('still returns a silent logger even when filePath is supplied', () => {
+    // Belt-and-suspenders: even if a test accidentally passes filePath,
+    // the NODE_ENV=test check short-circuits before any file is opened.
+    const logger = createDefaultLogger({ filePath: '/tmp/should-never-be-created' });
+    expect(logger.level).toBe('silent');
+  });
+
+  // Prove the production path actually writes to disk. Without this test we
+  // rely on "looks right in code review" for the file-sink behavior. By
+  // temporarily overriding NODE_ENV we exercise the real branch against a
+  // temp directory that cleans itself up.
+  //
+  // Pino's file transport runs in a worker thread for performance, so the
+  // file write is asynchronous. We poll for the file to appear and contain
+  // our event (up to 2 seconds), which is more robust than `logger.flush`
+  // against the transport boot timing.
+  it('writes JSONL to the given file path when NODE_ENV is not test', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wolf-logger-prod-'));
+    const filePath = path.join(tmpDir, 'wolf.log.jsonl');
+
+    // NOTE: this test also triggers pino's pretty console transport, which
+    // writes one line to the actual stderr. We can't stub that — pino
+    // transports run in an isolated worker_thread with its own stdio
+    // handles, so main-thread stubs don't reach it. Accept the single line
+    // of output as secondary evidence that the console transport works.
+
+    try {
+      // Pretend we're NOT in a test so createDefaultLogger takes the
+      // production branch and actually opens the file for append.
+      process.env.NODE_ENV = 'production';
+
+      const logger = createDefaultLogger({ filePath });
+      logger.info({ sample: 'field' }, 'prod.write.test');
+
+      // Poll for the file to contain our event. Pino's transport worker
+      // usually delivers within 50–200 ms; 2 s is a generous ceiling.
+      const parsed = await pollForFirstLogEntry(filePath, 2000);
+
+      expect(parsed.msg).toBe('prod.write.test');
+      expect(parsed.level).toBe(30); // info
+      expect(parsed.sample).toBe('field');
+    } finally {
+      // Always restore NODE_ENV and delete the temp workspace so the test
+      // is isolated from the rest of the suite.
+      process.env.NODE_ENV = originalNodeEnv;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Polls a log file until it contains at least one complete JSONL line, then
+// returns the parsed first line. Throws if the deadline passes first — the
+// caller's expect() assertions then explain the mystery failure.
+async function pollForFirstLogEntry(filePath: string, timeoutMs: number): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const contents = fs.readFileSync(filePath, 'utf-8');
+      const firstLine = contents.split('\n').find((line) => line.trim().length > 0);
+      if (firstLine !== undefined) {
+        return JSON.parse(firstLine);
+      }
+    } catch {
+      // File may not exist yet; loop and retry.
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`pollForFirstLogEntry: no log line appeared at ${filePath} within ${timeoutMs}ms`);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,192 +1,122 @@
 /**
- * Structured logger for wolf.
+ * Structured logging for wolf — backed by pino.
  *
- * Design:
- *   - Four levels: debug / info / warn / error.
- *   - All events are structured: (msg: string, fields?: Record<string, unknown>).
- *   - Sinks decide where events go; renderers decide how they look.
- *   - Console sink writes to stderr — stdout is reserved for command deliverables
- *     (parseable output, JSON payloads, MCP protocol frames).
- *   - File sink always writes JSONL — one event per line, grep/jq-friendly.
+ * Public API (what service code uses):
+ *   - `log`: facade object with `debug` / `info` / `warn` / `error` methods.
+ *   - `setDefaultLogger(logger)`: swap the underlying pino instance. Called
+ *     once by AppContext; used by tests to install a capture stream.
+ *   - `createSilentLogger()` / `createDefaultLogger()`: ready-made pino
+ *     instances for tests and production.
  *
- * Level filter:
- *   - WOLF_LOG=debug|info|warn|error (default: info).
- *   - Events below the threshold are dropped before any sink sees them.
+ * Why a facade over bare pino?
+ *   - Lets services call `log.info('event.name', { fields })` with message
+ *     first — matches the rest of our codebase and reads naturally. Pino's
+ *     native API is `(fields, msg)`, which we flip inside the facade.
+ *   - Lets us swap the underlying logger at runtime (test setup, capture
+ *     streams) without every service needing to import `pino` directly.
  *
- * Format (console only):
- *   - WOLF_LOG_FORMAT=pretty|json (default: pretty).
- *   - File sink is always json — mixing rendered text and structured data is pointless.
- *
- * Testing:
- *   - createMemorySink() captures events in memory for assertions.
- *   - createSilentLogger() discards everything — for test AppContexts.
+ * Safety in tests: Vitest sets `NODE_ENV=test` automatically. The module
+ * default picks up a silent pino, so log calls from any test run produce
+ * zero output and zero disk writes. Tests that want to assert on events
+ * install their own pino instance backed by `pino-test`'s `sink()`.
  */
-import fs from 'node:fs';
-import path from 'node:path';
+import pino, { type Logger as PinoLogger } from 'pino';
 
+// Map our level strings to pino's level strings (they match).
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
-export interface LogEvent {
-  ts: string;
-  level: LogLevel;
-  msg: string;
-  [key: string]: unknown;
-}
-
-export interface Logger {
-  debug(msg: string, fields?: Record<string, unknown>): void;
-  info(msg: string, fields?: Record<string, unknown>): void;
-  warn(msg: string, fields?: Record<string, unknown>): void;
-  error(msg: string, fields?: Record<string, unknown>): void;
-}
-
-export interface LogSink {
-  write(event: LogEvent): void;
-}
-
-export interface CreateLoggerOptions {
-  level?: LogLevel;
-  sinks?: LogSink[];
-}
-
-// Level ordering — events below the logger's threshold are silently dropped.
-const LEVEL_ORDER: Record<LogLevel, number> = {
-  debug: 0,
-  info: 1,
-  warn: 2,
-  error: 3,
-};
-
-class LoggerImpl implements Logger {
-  constructor(
-    private level: LogLevel,
-    private sinks: LogSink[],
-  ) {}
-
-  debug(msg: string, fields?: Record<string, unknown>): void {
-    this.emit('debug', msg, fields);
-  }
-  info(msg: string, fields?: Record<string, unknown>): void {
-    this.emit('info', msg, fields);
-  }
-  warn(msg: string, fields?: Record<string, unknown>): void {
-    this.emit('warn', msg, fields);
-  }
-  error(msg: string, fields?: Record<string, unknown>): void {
-    this.emit('error', msg, fields);
-  }
-
-  private emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): void {
-    if (LEVEL_ORDER[level] < LEVEL_ORDER[this.level]) return;
-    const event: LogEvent = {
-      ts: new Date().toISOString(),
-      level,
-      msg,
-      ...(fields ?? {}),
-    };
-    for (const sink of this.sinks) sink.write(event);
-  }
-}
-
-type Renderer = (event: LogEvent) => string;
-
-// Glyphs tag each event visually in pretty mode without costing a color escape.
-const GLYPHS: Record<LogLevel, string> = {
-  debug: '·',
-  info: '•',
-  warn: '⚠',
-  error: '✖',
-};
-
-// Pretty renderer drops ts/level from the inline string — the glyph already
-// carries the level, and timestamps add noise to interactive CLIs.
-const prettyRenderer: Renderer = (event) => {
-  const { ts: _ts, level, msg, ...fields } = event;
-  const fieldsStr = Object.keys(fields).length > 0
-    ? ' ' + Object.entries(fields).map(([k, v]) => `${k}=${formatValue(v)}`).join(' ')
-    : '';
-  return `${GLYPHS[level]} ${msg}${fieldsStr}`;
-};
-
-const jsonRenderer: Renderer = (event) => JSON.stringify(event);
-
-function formatValue(v: unknown): string {
-  if (v === null || v === undefined) return String(v);
-  if (typeof v === 'object') return JSON.stringify(v);
-  return String(v);
-}
-
 /**
- * Writes events to stderr. Stdout is intentionally left clean so commands
- * can pipe their deliverable output (job lists, JSON payloads) without
- * log noise contaminating the stream.
+ * Builds a silent pino instance — every event is discarded. Used as the
+ * module default so any log call that happens before setDefaultLogger
+ * runs (or in a test that doesn't configure a logger) is a no-op.
  */
-export function createConsoleSink(format: 'pretty' | 'json' = 'pretty'): LogSink {
-  const renderer = format === 'json' ? jsonRenderer : prettyRenderer;
-  return {
-    write(event) {
-      process.stderr.write(renderer(event) + '\n');
-    },
-  };
+export function createSilentLogger(): PinoLogger {
+  return pino({ level: 'silent' });
 }
 
 /**
- * Appends one JSON event per line to a file. Creates the parent directory
- * on construction. Uses synchronous append so crash mid-command still flushes
- * the last event — we pay a small I/O cost for that guarantee.
- */
-export function createFileSink(filePath: string): LogSink {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  return {
-    write(event) {
-      fs.appendFileSync(filePath, JSON.stringify(event) + '\n');
-    },
-  };
-}
-
-/**
- * Captures events in an in-memory array. For tests that want to assert on
- * what was logged.
- */
-export interface MemorySink extends LogSink {
-  readonly events: LogEvent[];
-  clear(): void;
-}
-export function createMemorySink(): MemorySink {
-  const events: LogEvent[] = [];
-  return {
-    events,
-    write(event) { events.push(event); },
-    clear() { events.length = 0; },
-  };
-}
-
-/**
- * Constructs a logger. Precedence for level and format:
- *   explicit option → WOLF_LOG / WOLF_LOG_FORMAT env var → default.
+ * Builds the production logger: level from WOLF_LOG env var (default info),
+ * pretty-printed to stderr unless WOLF_LOG_FORMAT=json is set. Pass
+ * `filePath` to also persist every event as JSONL.
  *
- * Default sink is a pretty-format console sink on stderr. Pass `sinks` to
- * compose multiple sinks (console + file) or to redirect output entirely.
+ * In tests (NODE_ENV=test), returns a silent logger instead — no matter
+ * what the caller asks for. Belt-and-suspenders safety against a test
+ * accidentally installing a real-sink logger.
  */
-export function createLogger(opts: CreateLoggerOptions = {}): Logger {
-  const level = opts.level ?? parseLevel(process.env.WOLF_LOG) ?? 'info';
-  const sinks = opts.sinks ?? [createConsoleSink(parseFormat(process.env.WOLF_LOG_FORMAT))];
-  return new LoggerImpl(level, sinks);
+export function createDefaultLogger(options: { filePath?: string } = {}): PinoLogger {
+  if (process.env.NODE_ENV === 'test') {
+    return createSilentLogger();
+  }
+
+  const level = process.env.WOLF_LOG ?? 'info';
+  const useJson = process.env.WOLF_LOG_FORMAT === 'json';
+
+  // Console transport: pretty for humans (default), JSON for pipes/log-shippers.
+  const consoleTransport = useJson
+    ? { target: 'pino/file', options: { destination: 2 } }      // 2 = stderr fd
+    : { target: 'pino-pretty', options: { destination: 2 } };
+
+  const targets: pino.TransportTargetOptions[] = [consoleTransport];
+
+  // File sink is optional so callers without a workspace (e.g. wolf --help)
+  // can still construct a logger.
+  if (options.filePath !== undefined) {
+    targets.push({
+      target: 'pino/file',
+      options: { destination: options.filePath, mkdir: true },
+      level,
+    });
+  }
+
+  return pino({ level }, pino.transport({ targets }));
+}
+
+// Module-level slot holding the currently active logger. Starts silent so
+// any log call that fires before setDefaultLogger has run (module-level
+// init code, tests that don't configure logging) is a no-op.
+let _default: PinoLogger = createSilentLogger();
+
+/**
+ * Install a new pino instance as the default. Called once by AppContext
+ * at startup. Tests may call it in a test body to install a capture
+ * stream; Vitest isolates module state per test file, so there's no
+ * cross-file leakage.
+ */
+export function setDefaultLogger(logger: PinoLogger): void {
+  _default = logger;
+}
+
+/** Returns the current default pino logger. Rarely needed — prefer `log`. */
+export function getLogger(): PinoLogger {
+  return _default;
 }
 
 /**
- * A logger that drops every event. Useful for test AppContexts where log
- * output would be noise in the test runner.
+ * Ergonomic facade. Services import this and call e.g.
+ *   log.info('tailor.pipeline.start', { jobId })
+ *
+ * Each method re-reads `_default` on every call so setDefaultLogger swaps
+ * take effect immediately — critical for the test pattern where a test
+ * installs a capture stream just before invoking the service.
+ *
+ * Argument order here (message, fields) is the reverse of pino's native
+ * (fields, message) because message-first reads more naturally in prose.
+ * The facade flips the arguments when calling through.
  */
-export function createSilentLogger(): Logger {
-  return new LoggerImpl('error', []);
+export const log = {
+  debug: (msg: string, fields?: Record<string, unknown>): void => emit('debug', msg, fields),
+  info:  (msg: string, fields?: Record<string, unknown>): void => emit('info',  msg, fields),
+  warn:  (msg: string, fields?: Record<string, unknown>): void => emit('warn',  msg, fields),
+  error: (msg: string, fields?: Record<string, unknown>): void => emit('error', msg, fields),
+};
+
+function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): void {
+  if (fields !== undefined) {
+    _default[level](fields, msg);
+  } else {
+    _default[level](msg);
+  }
 }
 
-function parseLevel(s: string | undefined): LogLevel | undefined {
-  if (s === 'debug' || s === 'info' || s === 'warn' || s === 'error') return s;
-  return undefined;
-}
-
-function parseFormat(s: string | undefined): 'pretty' | 'json' {
-  return s === 'json' ? 'json' : 'pretty';
-}
+/** Alias for consumers that want to name the type. */
+export type Logger = PinoLogger;


### PR DESCRIPTION
Two enhancements queued after PR #71, shipped as two commits on one PR.

## Commit 1 — \`refactor(style)\`: codebase-wide readability sweep

Pure refactor, zero behavior change, all 228 existing tests pass without modification. Applies the \"simple, readable code\" preference to older files that predate it — named intermediate variables, explicit if/else, \`//\` comments above each logical block (matches the CLAUDE.md rule).

Touched where it paid off:
- \`src/service/impl/resumeCoverLetterServiceImpl.ts\`, \`tailoringBriefServiceImpl.ts\`, \`renderServiceImpl.ts\` — extracted helpers (\`formatProfileUrls\`, \`buildContactSection\`, \`buildJdSection\`, \`validateNonEmptyResponse\`, \`withRenderedPage\`, etc.). Eliminated duplication between \`renderPdf\` and \`renderCoverLetterPdf\`.
- \`src/application/impl/tailorApplicationServiceImpl.ts\` — named the conditional CL promise, hoisted \`clStep?.x ?? null\` into locals computed once.
- \`src/commands/env/index.ts\` — extracted \`WOLF_EXPORT_LINE_RE\` constant, factored \`findWolfExportsAcrossRcFiles\` / \`removeWolfExportsFromRcFile\` helpers.
- \`src/repository/impl/sqliteJobRepositoryImpl.ts\` — dropped redundant \`?? null\` coalesces on already-nullable fields (PR #71 review nit #6).

Audited but left alone because they were already clean: \`src/utils/**\`, \`src/cli/**\`, \`src/commands/init/**\` (already has \`── Step N ──\` dividers), \`src/service/impl/render/fit.ts\` (high-risk binary-search logic, well-commented), \`src/service/impl/batchServiceImpl.ts\` (stub), \`src/types/**\` (no logic).

## Commit 2 — \`feat(logger)\`: service retrofit + pino migration

Service retrofit was planned from the start. The pino migration came out of user pushback — our hand-rolled logger required non-obvious Null-Object-pattern knowledge that would have been a footgun for future contributors. Swapping to pino trades 190 lines of custom code for ~100 lines of wrapping, plus industry-standard testing idioms via \`pino-test\`.

**Library swap:**
- \`src/utils/logger.ts\` rewritten as a pino wrapper. Exports \`log\` facade (message-first arg order for readability), \`setDefaultLogger\` / \`getLogger\`, \`createSilentLogger\`, \`createDefaultLogger\`.
- \`createDefaultLogger({ filePath })\` configures pino-pretty stderr + JSONL file transport. **NODE_ENV=test short-circuits to silent regardless of filePath** — belt-and-suspenders against test leakage.
- Deleted: \`Logger\` interface, \`LoggerImpl\`, \`createConsoleSink\`, \`createFileSink\`, \`createMemorySink\`, \`createLogger\` with custom sinks.
- Deps: \`pino\` + \`pino-pretty\` (runtime); \`pino-test\` (dev).

**Service retrofit — events at state transitions:**
- \`ResumeCoverLetterServiceImpl\`: \`ai.resume.start/done/empty_response\` + same for cover letter. \`durationMs\`, \`responseLength\`, \`profileId\`.
- \`TailoringBriefServiceImpl\`: \`ai.brief.start/done/empty_response\`. \`hintProvided\` field on start.
- \`RenderServiceImpl\`: \`render.start/done\` with iterations + finalFontSize + pdfSizeBytes + durationMs; \`render.fit.cannot_fit\` / \`cannot_fill\` warn before rethrow.
- \`TailorApplicationServiceImpl\`: \`tailor.pipeline.start/analyze.done/pipeline.done\`; \`tailor.context.job_missing\` / \`tailor.brief.read_failed\` error before throws.
- \`StatusApplicationServiceImpl\`: \`status.counter.failed\` (pre-existing, migrated to \`log\` facade).
- \`BatchServiceImpl\`: skipped (stub; logger lands with M2 Hunter).

**Services do not take \`logger\` as a ctor arg.** They import \`log\` directly. Rationale: logging is cross-cutting infrastructure, and ctor-injection of it grew unwieldy (\`TailorApplicationServiceImpl\` would have become 8 args). pino's module-level convention matches \`debug\`, \`pino\`, \`winston\` ecosystem norms.

**Tests:**
- \`logger.test.ts\` rewritten with pino-test's \`sink()\` for event capture.
- **New end-to-end proof test:** *\"writes JSONL to the given file path when NODE_ENV is not test\"* — flips NODE_ENV to production, writes through a real pino logger, polls a temp file, parses the JSONL line. Covers the production file-sink path that would otherwise rely on code review. Emits one line of pino-pretty stderr per run (transports run in isolated worker threads, can't be suppressed from main thread — documented in a comment).
- Three event-capture tests migrated from hand-rolled memory sinks to pino-test.
- Vitest's file-level module isolation means only test files that actually install a memory sink need an \`afterEach\` reset. 3 files do; 18+ others have zero logger setup.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 222/222 pass (went 228 → 222 because we removed tests of custom sink implementations that pino replaces; their behavior is now covered by pino's own test suite)
- [x] Event-capture tests prove state transitions + error paths fire the right events with the right fields
- [x] Production file-write path proven by the temp-file test
- [ ] Manual smoke: \`wolf tailor\` in a seeded workspace → verify pino-pretty stderr + JSONL file appears at \`data/logs/wolf.log.jsonl\`
- [ ] Manual smoke: \`WOLF_LOG=debug\` → verify debug events appear; \`WOLF_LOG_FORMAT=json\` → verify stderr switches to JSON

## Out of scope (follow-ups)

- \`wolf status\` counters that don't yet exist (hunt / fill / reach) — register when those modules land
- \`BatchServiceImpl\` logger retrofit — with M2 Hunter
- Global Vitest test-setup file (\`setupFiles: ['./src/test-setup.ts']\`) that would eliminate the 3 \`afterEach\` calls — deferred until it becomes painful