### PR TITLE
docs(contributing): require smoke pre-PR; acceptance is judgment-call

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,56 @@ If you find a problem, go back to Step 6, fix it, and test again. Once you're sa
 
 ---
 
+## Step 8.5: Run the smoke suite (required) and consider acceptance (judgment call)
+
+> [!IMPORTANT]
+> Unit tests (`npm test`) and the build are already enforced by CI on every PR — you don't need to babysit them. But there are two test layers CI does NOT run, and at least one of them is your responsibility before opening a PR.
+
+Wolf has three test layers. Two of them you must consider:
+
+| Layer | Cost | Required before PR? | Who runs it |
+|---|---|---|---|
+| **Unit tests** (`npm test`) | free | Already enforced by CI | CI on every push |
+| **Smoke suite** (`test/smoke/`) | free | **Required** for any PR that changes CLI behavior, commands, build modes, or workspace handling | You, locally, before opening the PR |
+| **Acceptance suite** (`test/acceptance/`) | ~$1-3 of Anthropic API per full run | **Case by case** — see below | You (if your change touches AI), or the maintainer |
+
+### Smoke suite — required
+
+The smoke suite is the fast gate. It proves the dev build, workspace isolation, and core CLI paths still work. It uses `/tmp/wolf-test/` workspaces only and never touches your real `~/wolf` or shell RC files. No API key needed.
+
+How to run: copy the orchestrator prompt from [test/smoke/README.md](test/smoke/README.md) into Claude Code (or any agent runner) and let it dispatch the groups. It will write a report under `test/runs/smoke-<timestamp>/` and update `test/runs/LATEST.md`.
+
+Pass criteria: every smoke group reports PASS. Paste the smoke `report.md` summary line (e.g. "9 / 9 PASS") into your PR description so the reviewer can confirm at a glance.
+
+If smoke fails because of a pre-existing issue unrelated to your change, say so in the PR description and link the failing report — don't silently skip.
+
+### Acceptance suite — case by case
+
+The acceptance suite is the coverage gate. It exercises real AI calls against the Anthropic API and uses an AI reviewer to judge artifact quality (resume / cover letter PDFs, etc.). One full run costs roughly $1-3 in API spend and takes 5-15 minutes.
+
+Run it (locally) when your change has any of these characteristics:
+
+- Touches `src/service/` or `src/application/`
+- Touches a `.md` prompt file under `src/service/impl/prompts/`
+- Touches `src/service/impl/render/` or `tailorApplicationServiceImpl.ts`
+- Adds or changes a use case or acceptance criterion in `docs/requirements/`
+- Strengthens or relaxes any AC currently mapped to an implemented acceptance group (see [test/acceptance/COVERAGE.md](test/acceptance/COVERAGE.md))
+
+Skip it (and say so in the PR description) when your change is:
+
+- Pure docs / README / comment edits
+- A small refactor inside `src/utils/` with full unit-test coverage
+- A new acceptance case added to a planned (not implemented) group
+- A typo or formatting fix
+
+If you're not sure, ask in the PR description: "I didn't run acceptance because X — do you want me to before merge?" The maintainer will tell you yes or no. Better to ask than to silently skip a needed run.
+
+How to run: copy the orchestrator prompt from [test/acceptance/README.md](test/acceptance/README.md) "How To Run" section into Claude Code. You'll need `WOLF_ANTHROPIC_API_KEY` set. The orchestrator writes a full run report under `test/runs/acceptance-<timestamp>/`. Paste the suite-level summary line into your PR description.
+
+If you don't have an API key and your change clearly needs acceptance, mention it in the PR — the maintainer can run it for you. Don't let the API requirement block you from contributing.
+
+---
+
 ## Step 9: Open a Pull Request
 
 > A Pull Request (PR) is how you tell the project owner "I'm done — please review and merge this." Make sure the PR targets the original wolf repository's base branch, not your own fork.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,7 @@ Wolf has three test layers:
 
 - Unit tests (`npm test`): verify function-level logic. CI already runs this on every PR (`npm ci + npm run build + npm test`); nothing to do locally.
 - Smoke suite (`test/smoke/`): runs the core CLI commands to confirm the build, workspace isolation, and basic flows still work. Free, no API key, a few minutes.
-- Acceptance suite (`test/acceptance/`): calls the real Anthropic API to drive the full tailor pipeline; an AI reviewer scores the resume / cover letter. Around \$0.20-0.50 per run, 5-15 minutes.
+- Acceptance suite (`test/acceptance/`): calls the real Anthropic API to drive the full tailor pipeline; an AI reviewer scores the resume / cover letter. Around \$0.20-0.50 per run. Compute time is under 10 minutes, but the orchestrator dispatches sub-agents during the run and Claude Code may prompt for permission — please stay nearby to approve in time.
 
 Before opening a PR, please:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,34 +261,37 @@ If you find a problem, go back to Step 6, fix it, and test again. Once you're sa
 
 ---
 
-## Step 8.5: Run the smoke suite (required) and consider acceptance (judgment call)
+## Step 8.5: Run the test suites
 
-> [!IMPORTANT]
-> Unit tests (`npm test`) and the build are already enforced by CI on every PR — you don't need to babysit them. But there are two test layers CI does NOT run, and at least one of them is your responsibility before opening a PR.
+Wolf has three test layers:
 
-Wolf has three test layers. Two of them you must consider:
+- Unit tests (`npm test`): verify function-level logic. CI already runs this on every PR (`npm ci + npm run build + npm test`); nothing to do locally.
+- Smoke suite (`test/smoke/`): runs the core CLI commands to confirm the build, workspace isolation, and basic flows still work. Free, no API key, a few minutes.
+- Acceptance suite (`test/acceptance/`): calls the real Anthropic API to drive the full tailor pipeline; an AI reviewer scores the resume / cover letter. Around \$0.20-0.50 per run, 5-15 minutes.
 
-| Layer | Cost | Required before PR? | Who runs it |
+Before opening a PR, please:
+
+| Layer | Cost | Pre-PR | How |
 |---|---|---|---|
-| **Unit tests** (`npm test`) | free | Already enforced by CI | CI on every push |
-| **Smoke suite** (`test/smoke/`) | free | **Required** for any PR that changes CLI behavior, commands, build modes, or workspace handling | You, locally, before opening the PR |
-| **Acceptance suite** (`test/acceptance/`) | ~$1-3 of Anthropic API per full run | **Case by case** — see below | You (if your change touches AI), or the maintainer |
+| Unit tests | free | Nothing — CI runs it | CI |
+| Smoke suite | free | Please run it if your change touches CLI / commands / build modes / workspace handling | Locally, see below |
+| Acceptance suite | ~$0.20-0.50 | Case by case, see below | Locally, or ask the maintainer |
 
-### Smoke suite — required
+### Smoke suite
 
-The smoke suite is the fast gate. It proves the dev build, workspace isolation, and core CLI paths still work. It uses `/tmp/wolf-test/` workspaces only and never touches your real `~/wolf` or shell RC files. No API key needed.
+Fast gate. Uses `/tmp/wolf-test/` workspaces only — never touches your real `~/wolf` or shell RC files.
 
-How to run: copy the orchestrator prompt from [test/smoke/README.md](test/smoke/README.md) into Claude Code (or any agent runner) and let it dispatch the groups. It will write a report under `test/runs/smoke-<timestamp>/` and update `test/runs/LATEST.md`.
+How to run: please copy the orchestrator prompt from [test/smoke/README.md](test/smoke/README.md) into Claude Code (or another agent runner) and let it dispatch the groups. Results land under `test/runs/smoke-<timestamp>/` and `test/runs/LATEST.md` is updated.
 
-Pass criteria: every smoke group reports PASS. Paste the smoke `report.md` summary line (e.g. "9 / 9 PASS") into your PR description so the reviewer can confirm at a glance.
+Once it's done, please paste the smoke `report.md` summary line (e.g. "9 / 9 PASS") into your PR description.
 
-If smoke fails because of a pre-existing issue unrelated to your change, say so in the PR description and link the failing report — don't silently skip.
+If smoke fails for a reason unrelated to your change (e.g. a pre-existing issue), please mention it in the PR description and link the failing report.
 
-### Acceptance suite — case by case
+### Acceptance suite
 
-The acceptance suite is the coverage gate. It exercises real AI calls against the Anthropic API and uses an AI reviewer to judge artifact quality (resume / cover letter PDFs, etc.). One full run costs roughly $1-3 in API spend and takes 5-15 minutes.
+Deeper than smoke: real AI calls produce a resume + cover letter, and a separate AI reviewer scores the output. About \$0.20-0.50 per full tailor-group run based on real usage data — small but not zero, which is why this is a judgment call rather than a blanket requirement.
 
-Run it (locally) when your change has any of these characteristics:
+Please run it when your change has any of these characteristics:
 
 - Touches `src/service/` or `src/application/`
 - Touches a `.md` prompt file under `src/service/impl/prompts/`
@@ -296,18 +299,18 @@ Run it (locally) when your change has any of these characteristics:
 - Adds or changes a use case or acceptance criterion in `docs/requirements/`
 - Strengthens or relaxes any AC currently mapped to an implemented acceptance group (see [test/acceptance/COVERAGE.md](test/acceptance/COVERAGE.md))
 
-Skip it (and say so in the PR description) when your change is:
+You can skip it (please add "skipped acceptance because X" to the PR description) when your change is:
 
 - Pure docs / README / comment edits
-- A small refactor inside `src/utils/` with full unit-test coverage
-- A new acceptance case added to a planned (not implemented) group
+- A small refactor inside `src/utils/` already covered by unit tests
+- A new acceptance case added to a planned (not yet implemented) group
 - A typo or formatting fix
 
-If you're not sure, ask in the PR description: "I didn't run acceptance because X — do you want me to before merge?" The maintainer will tell you yes or no. Better to ask than to silently skip a needed run.
+If you're not sure, please just ask in the PR description: "I didn't run acceptance because X — do you want me to?" The maintainer will reply.
 
-How to run: copy the orchestrator prompt from [test/acceptance/README.md](test/acceptance/README.md) "How To Run" section into Claude Code. You'll need `WOLF_ANTHROPIC_API_KEY` set. The orchestrator writes a full run report under `test/runs/acceptance-<timestamp>/`. Paste the suite-level summary line into your PR description.
+How to run: please copy the orchestrator prompt from [test/acceptance/README.md](test/acceptance/README.md) "How To Run" section into Claude Code. You'll need `WOLF_ANTHROPIC_API_KEY` set. The full run report lands under `test/runs/acceptance-<timestamp>/`; please paste the suite-level summary line into your PR description.
 
-If you don't have an API key and your change clearly needs acceptance, mention it in the PR — the maintainer can run it for you. Don't let the API requirement block you from contributing.
+If you don't have an API key but the change needs acceptance, please mention it in the PR and the maintainer can run it for you.
 
 ---
 

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -237,6 +237,54 @@ wolf <你实现的命令>     # 真实跑一遍
 
 如果发现问题，回到第六步修复，再重新测试。满意了再进下一步。
 
+## 第八点五步：跑 smoke 套件（必须）+ 判断要不要跑 acceptance（看情况）
+
+> [!IMPORTANT]
+> 单元测试（`npm test`）和 build 已经被 CI 在每个 PR 上自动强制了，你**不用**自己再操心。但还有两层测试 CI 不会跑，至少其中一层是开 PR 前你的责任。
+
+Wolf 有三层测试，其中两层你必须考虑：
+
+| 层 | 成本 | PR 前是否必跑？ | 谁跑 |
+|---|---|---|---|
+| **单元测试**（`npm test`） | 免费 | 已经被 CI 强制 | CI（每次 push） |
+| **Smoke 套件**（`test/smoke/`） | 免费 | **必须**——只要 PR 改了 CLI 行为、命令、build mode 或 workspace 处理 | 你，本地，开 PR 前 |
+| **Acceptance 套件**（`test/acceptance/`） | 一次完整 run 约 $1-3 Anthropic API 费用 | **看情况**——见下 | 你（如果改了 AI 相关代码）或维护者 |
+
+### Smoke 套件——必须
+
+Smoke 是快速门禁。它验证 dev build、workspace 隔离、核心 CLI 路径仍然 OK。它只用 `/tmp/wolf-test/` 工作区，永远不会碰你真实的 `~/wolf` 或 shell RC 文件。**不需要 API key**。
+
+怎么跑：把 [test/smoke/README_zh.md](test/smoke/README_zh.md) 里的 orchestrator prompt 复制给 Claude Code（或别的 agent runner），它会派发各 group。结果会写到 `test/runs/smoke-<时间戳>/`，并更新 `test/runs/LATEST.md`。
+
+通过标准：每个 smoke group PASS。把 smoke `report.md` 的总结行（例如 "9 / 9 PASS"）粘到 PR 描述里，方便 reviewer 一眼确认。
+
+如果 smoke fail 是个跟你改动无关的旧问题，**在 PR 描述里说明并贴出失败报告链接** —— 不要静默跳过。
+
+### Acceptance 套件——看情况
+
+Acceptance 是覆盖门禁。它会真的调 Anthropic API，并用 AI reviewer 评审产物质量（resume / cover letter PDF 等）。一次完整 run 大约 $1-3 API 花费、5-15 分钟。
+
+**满足下列任一条件就跑**：
+
+- 改了 `src/service/` 或 `src/application/`
+- 改了 `src/service/impl/prompts/` 下任何 `.md` prompt
+- 改了 `src/service/impl/render/` 或 `tailorApplicationServiceImpl.ts`
+- 在 `docs/requirements/` 里新增或改了 use case / acceptance criterion
+- 强化或放宽了任何已映射到 implemented acceptance group 的 AC（见 [test/acceptance/COVERAGE_zh.md](test/acceptance/COVERAGE_zh.md)）
+
+**下列情况可以跳过**（在 PR 描述里写一句"未跑 acceptance，原因是 X"）：
+
+- 纯文档 / README / 注释改动
+- `src/utils/` 的小重构，且单元测试已覆盖
+- 只是给某个 planned（尚未 implemented）group 加了新的 acceptance case
+- 错别字 / 格式修复
+
+**不确定的话**：在 PR 描述里直接问"我没跑 acceptance 因为 X，你需要我在 merge 前跑吗？"维护者会告诉你跑还是不跑。**问清楚比静默跳过更负责**。
+
+怎么跑：把 [test/acceptance/README_zh.md](test/acceptance/README_zh.md) 里"如何运行"段的 orchestrator prompt 复制给 Claude Code。需要先设置 `WOLF_ANTHROPIC_API_KEY`。Orchestrator 会写一份完整 run 报告到 `test/runs/acceptance-<时间戳>/`。把套件层级的总结行粘到 PR 描述里。
+
+如果你**没有 API key 但你的改动确实需要 acceptance**：在 PR 里说明，维护者可以替你跑。**不要因为没有 API key 就放弃贡献**。
+
 ## 第九步：发 Pull Request
 
 > Pull Request（PR）是你告诉项目 owner"我写完了，请帮我看看能不能合并进去"的方式。注意：PR 的目标是原始 wolf 仓库的 base branch，不是你自己的 fork。

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -237,53 +237,56 @@ wolf <你实现的命令>     # 真实跑一遍
 
 如果发现问题，回到第六步修复，再重新测试。满意了再进下一步。
 
-## 第八点五步：跑 smoke 套件（必须）+ 判断要不要跑 acceptance（看情况）
+## 第八点五步：跑测试套件
 
-> [!IMPORTANT]
-> 单元测试（`npm test`）和 build 已经被 CI 在每个 PR 上自动强制了，你**不用**自己再操心。但还有两层测试 CI 不会跑，至少其中一层是开 PR 前你的责任。
+Wolf 有三层测试：
 
-Wolf 有三层测试，其中两层你必须考虑：
+- 单元测试（`npm test`）：验证函数级逻辑。CI 会在每个 PR 上自动跑（`npm ci + npm run build + npm test`），本地不用操心。
+- Smoke 套件（`test/smoke/`）：跑一遍核心 CLI 命令，验证 build、workspace 隔离、基础流程。免费，无需 API key，几分钟跑完。
+- Acceptance 套件（`test/acceptance/`）：真调 Anthropic API 跑完整 tailor 流程，AI reviewer 评审 resume / cover letter 产物。每次约 $0.20-0.50、5-15 分钟。
 
-| 层 | 成本 | PR 前是否必跑？ | 谁跑 |
+PR 前请关注：
+
+| 层 | 成本 | PR 前 | 怎么跑 |
 |---|---|---|---|
-| **单元测试**（`npm test`） | 免费 | 已经被 CI 强制 | CI（每次 push） |
-| **Smoke 套件**（`test/smoke/`） | 免费 | **必须**——只要 PR 改了 CLI 行为、命令、build mode 或 workspace 处理 | 你，本地，开 PR 前 |
-| **Acceptance 套件**（`test/acceptance/`） | 一次完整 run 约 $1-3 Anthropic API 费用 | **看情况**——见下 | 你（如果改了 AI 相关代码）或维护者 |
+| 单元测试 | 免费 | 无需操作，CI 自动 | CI |
+| Smoke 套件 | 免费 | 改了 CLI / 命令 / build mode / workspace 时请跑一下 | 本地，见下 |
+| Acceptance 套件 | ~$0.20-0.50 | 看情况，见下 | 本地，或请维护者代跑 |
 
-### Smoke 套件——必须
+### Smoke 套件
 
-Smoke 是快速门禁。它验证 dev build、workspace 隔离、核心 CLI 路径仍然 OK。它只用 `/tmp/wolf-test/` 工作区，永远不会碰你真实的 `~/wolf` 或 shell RC 文件。**不需要 API key**。
+Smoke 是快速门禁，只用 `/tmp/wolf-test/` 工作区，不碰真实的 `~/wolf` 或 shell RC 文件。
 
-怎么跑：把 [test/smoke/README_zh.md](test/smoke/README_zh.md) 里的 orchestrator prompt 复制给 Claude Code（或别的 agent runner），它会派发各 group。结果会写到 `test/runs/smoke-<时间戳>/`，并更新 `test/runs/LATEST.md`。
+怎么跑：请把 [test/smoke/README_zh.md](test/smoke/README_zh.md) 里的 orchestrator prompt 复制给 Claude Code（或别的 agent runner），自动派发各 group。结果会写到 `test/runs/smoke-<时间戳>/`，并更新 `test/runs/LATEST.md`。
 
-通过标准：每个 smoke group PASS。把 smoke `report.md` 的总结行（例如 "9 / 9 PASS"）粘到 PR 描述里，方便 reviewer 一眼确认。
+跑完后，请把 smoke `report.md` 的总结行（例如 "9 / 9 PASS"）贴到 PR 描述里。
 
-如果 smoke fail 是个跟你改动无关的旧问题，**在 PR 描述里说明并贴出失败报告链接** —— 不要静默跳过。
+如果 smoke fail 跟改动无关（比如已有旧问题），请在 PR 描述里说明并附失败报告链接。
 
-### Acceptance 套件——看情况
+### Acceptance 套件
 
-Acceptance 是覆盖门禁。它会真的调 Anthropic API，并用 AI reviewer 评审产物质量（resume / cover letter PDF 等）。一次完整 run 大约 $1-3 API 花费、5-15 分钟。
+Acceptance 比 smoke 更深入：调真实 AI 接口生成 resume + cover letter，再让 AI reviewer 评审。一次完整 tailor 组 acceptance 按实测约 $0.20-0.50。不算贵但不是零，所以采用"看情况判断"而不是统一强制。
 
-**满足下列任一条件就跑**：
+下列情况请跑一下：
 
-- 改了 `src/service/` 或 `src/application/`
-- 改了 `src/service/impl/prompts/` 下任何 `.md` prompt
-- 改了 `src/service/impl/render/` 或 `tailorApplicationServiceImpl.ts`
-- 在 `docs/requirements/` 里新增或改了 use case / acceptance criterion
-- 强化或放宽了任何已映射到 implemented acceptance group 的 AC（见 [test/acceptance/COVERAGE_zh.md](test/acceptance/COVERAGE_zh.md)）
+- 改动到 `src/service/` 或 `src/application/`
+- 改动到 `src/service/impl/prompts/` 下的 `.md` prompt
+- 改动到 `src/service/impl/render/` 或 `tailorApplicationServiceImpl.ts`
+- 在 `docs/requirements/` 里新增或修改了 use case / acceptance criterion
+- 强化或放宽了已 implemented acceptance group 覆盖的 AC（见 [test/acceptance/COVERAGE_zh.md](test/acceptance/COVERAGE_zh.md)）
 
-**下列情况可以跳过**（在 PR 描述里写一句"未跑 acceptance，原因是 X"）：
+下列情况可以跳过（请在 PR 描述里写一句"未跑 acceptance，原因是 X"）：
 
-- 纯文档 / README / 注释改动
-- `src/utils/` 的小重构，且单元测试已覆盖
-- 只是给某个 planned（尚未 implemented）group 加了新的 acceptance case
-- 错别字 / 格式修复
+- 纯文档 / README / 注释
+- `src/utils/` 小重构，单元测试已覆盖
+- 只是给 planned（尚未 implemented）group 加新的 acceptance case
+- 错别字 / 格式
 
-**不确定的话**：在 PR 描述里直接问"我没跑 acceptance 因为 X，你需要我在 merge 前跑吗？"维护者会告诉你跑还是不跑。**问清楚比静默跳过更负责**。
+不确定要不要跑，请直接在 PR 描述里问一句："我没跑 acceptance 因为 X，需要我跑吗？" 维护者会回复。
 
-怎么跑：把 [test/acceptance/README_zh.md](test/acceptance/README_zh.md) 里"如何运行"段的 orchestrator prompt 复制给 Claude Code。需要先设置 `WOLF_ANTHROPIC_API_KEY`。Orchestrator 会写一份完整 run 报告到 `test/runs/acceptance-<时间戳>/`。把套件层级的总结行粘到 PR 描述里。
+怎么跑：请把 [test/acceptance/README_zh.md](test/acceptance/README_zh.md) 里"如何运行"段的 orchestrator prompt 复制给 Claude Code，需要先设置 `WOLF_ANTHROPIC_API_KEY`。完成后报告会写到 `test/runs/acceptance-<时间戳>/`，请把套件层级的总结行贴到 PR 描述里。
 
-如果你**没有 API key 但你的改动确实需要 acceptance**：在 PR 里说明，维护者可以替你跑。**不要因为没有 API key 就放弃贡献**。
+没有 API key 但改动需要 acceptance：请在 PR 里说一声，维护者可以代跑。
 
 ## 第九步：发 Pull Request
 

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -243,7 +243,7 @@ Wolf 有三层测试：
 
 - 单元测试（`npm test`）：验证函数级逻辑。CI 会在每个 PR 上自动跑（`npm ci + npm run build + npm test`），本地不用操心。
 - Smoke 套件（`test/smoke/`）：跑一遍核心 CLI 命令，验证 build、workspace 隔离、基础流程。免费，无需 API key，几分钟跑完。
-- Acceptance 套件（`test/acceptance/`）：真调 Anthropic API 跑完整 tailor 流程，AI reviewer 评审 resume / cover letter 产物。每次约 $0.20-0.50、5-15 分钟。
+- Acceptance 套件（`test/acceptance/`）：真调 Anthropic API 跑完整 tailor 流程，AI reviewer 评审 resume / cover letter 产物。每次约 $0.20-0.50。计算时间 10 分钟内，但跑的过程中 orchestrator 会派发 sub-agent，期间可能弹 Claude Code 的权限确认，请保持在场及时通过。
 
 PR 前请关注：
 


### PR DESCRIPTION
## Summary

CI already enforces unit tests + build on every PR — contributors don't need to babysit that. This PR adds two new sections to `CONTRIBUTING.md` (and `CONTRIBUTING_zh.md`) covering the test layers CI does **not** run:

- **Smoke suite** — required before PR for anything touching CLI / commands / build modes / workspace handling. Free, no API key.
- **Acceptance suite** — case-by-case, with explicit "run when..." and "skip when..." lists. Costs ~\$0.20-0.50 per full tailor-group run (real usage: 3 runs cost \$0.47 total). Each run takes under 10 minutes of compute, but contributors should stay nearby to handle Claude Code approval prompts that the orchestrator dispatches during the run. Contributors without an API key can ask the maintainer to run it.

Both sections point at the existing orchestrator prompts in `test/smoke/README.md` and `test/acceptance/README.md` "How To Run" so the contributor can dispatch via Claude Code directly.

## Why now

Once the AI-orchestrated test framework landed (#74), there was no contributor-facing guidance on which suite to run when. Without this, smoke gets skipped (we lose the cheap regression net) or acceptance gets skipped silently on AI-touching changes (we lose the rubric coverage). The judgment-call framing on acceptance keeps the cost barrier from blocking new contributors entirely.

## Files changed

- `CONTRIBUTING.md` — new "Step 8.5" section between dog-fooding and PR
- `CONTRIBUTING_zh.md` — same in Chinese