### PR TITLE
docs: dev-build setup for contributors (CONTRIBUTING + README quick start)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,42 @@ If a test fails, paste the full error message into your AI and ask for help. Sti
 
 ---
 
+## Step 3.5: Use the dev build (don't pollute your real workspace)
+
+> [!TIP]
+> You can paste this whole section into Claude Code / ChatGPT and ask the AI to set it up for you. Just tell the AI which workspace directory you want and where your API key lives.
+
+The `npm run build` step above produces the **stable build**. The stable build defaults to `~/wolf` and reads your real `WOLF_*` environment variables — meaning if you use it for development, your code changes will write into your actual job-search workspace and consume your real API budget. Don't do that.
+
+Use the **dev build** for local development instead. It's a separate build mode that defaults to `~/wolf-dev`, prefers `WOLF_DEV_*` env vars, prints a "dev" banner so you always know which build you're running, and exposes MCP tools as `wolfdev_*` so they don't collide with the real `wolf_*` tools in any AI client you've configured.
+
+```bash
+npm run build:dev                              # build the dev-aware dist
+export WOLF_DEV_HOME=~/wolf-dev                # or any directory you want for testing
+export WOLF_DEV_ANTHROPIC_API_KEY=sk-ant-...   # keep your dev key separate from your real one
+
+npm run wolf -- init --dev --empty             # create a dev workspace (no prompts)
+npm run wolf -- <command>                      # run any wolf command against the dev build
+```
+
+`npm run wolf -- ...` runs `node dist/cli/index.js`, so you don't need `npm install -g .` and you won't shadow any stable `wolf` binary you have installed elsewhere.
+
+Key differences between stable and dev builds:
+
+| | Stable build | Dev build |
+|---|---|---|
+| How to build | `npm run build` | `npm run build:dev` |
+| How to invoke | global `wolf` (after `npm install -g .`) or `node dist/cli/index.js` | `npm run wolf -- <command>` |
+| Default workspace | `~/wolf` (or `WOLF_HOME`) | `~/wolf-dev` (or `WOLF_DEV_HOME`) |
+| Env var precedence | `WOLF_*` only | `WOLF_DEV_*` first, then `WOLF_*` |
+| MCP tool names | `wolf_*` | `wolfdev_*` |
+| CLI banner | none | "dev" banner on every invocation |
+| `wolf init --dev` | rejected with a clear error | accepted |
+
+If you ever see `wolf init` prompting about your real `~/wolf` directory while you're trying to develop, you ran the stable build by mistake — re-run `npm run build:dev` and use `npm run wolf -- ...` instead.
+
+---
+
 ## Step 4: Find a task
 
 > Tasks in open source projects are publicly posted — like a bounty board. Anyone can pick one up, do the work, and submit it. Once approved, your code is officially part of the project.
@@ -244,11 +280,12 @@ git push -u origin feat/your-feature-name
 
 **Dog fooding** means "eating your own dog food" — using the tool you built in a real scenario, not just checking that CI is green.
 
+Run it against the **dev build** so it stays in your dev workspace (`WOLF_DEV_HOME`) and uses your dev API key. See Step 3.5 if you haven't set that up yet.
+
 ```bash
-cd /path/to/wolf      # navigate to your wolf project root
-npm run build         # recompile
-npm install -g .      # install wolf locally so you can run it as a command
-wolf <your-command>   # run it for real
+cd /path/to/wolf            # navigate to your wolf project root
+npm run build:dev           # recompile the dev build after your changes
+npm run wolf -- <command>   # run it against the dev workspace
 ```
 
 Ask yourself:

--- a/CONTRIBUTING_zh.md
+++ b/CONTRIBUTING_zh.md
@@ -115,6 +115,40 @@ npm test  # 运行测试，应该全部通过
 
 如果有测试失败，先把错误信息完整复制给 AI 问一下。还是搞不定，联系项目 owner。
 
+## 第三点五步：用 dev build 开发（不要污染你真实的 workspace）
+
+> [!TIP]
+> 这一段可以整段贴给 Claude Code / ChatGPT，让 AI 帮你执行下面的命令。你只需要告诉 AI 想用哪个目录当 workspace、API key 放在哪。
+
+上面的 `npm run build` 装的是 **stable build**。Stable build 默认 workspace 是 `~/wolf`，读你真实的 `WOLF_*` 环境变量 —— 也就是说如果你拿它来开发，改动会写进你真实的求职 workspace、消耗你真实的 API 预算。请不要这样做。
+
+本地开发请用 **dev build**。这是另一个 build mode，默认 workspace 是 `~/wolf-dev`、优先读 `WOLF_DEV_*` env、CLI 会打印 dev banner（这样你随时知道现在跑的是哪个 build）、MCP 工具名是 `wolfdev_*`（避免与 AI 客户端里已配置的真实 `wolf_*` 工具冲突）。
+
+```bash
+npm run build:dev                              # 编译 dev-aware dist
+export WOLF_DEV_HOME=~/wolf-dev                # 或任何你想测试的目录
+export WOLF_DEV_ANTHROPIC_API_KEY=sk-ant-...   # 跟生产 key 分开
+
+npm run wolf -- init --dev --empty             # 创建 dev workspace（无交互提示）
+npm run wolf -- <command>                      # 用 dev build 跑任意 wolf 命令
+```
+
+`npm run wolf -- ...` 实际跑的是 `node dist/cli/index.js`，所以你不用 `npm install -g .`，也不会跟你机器上别处装的 stable `wolf` 互相覆盖。
+
+Stable 和 dev build 的关键区别：
+
+| | Stable build | Dev build |
+|---|---|---|
+| 怎么 build | `npm run build` | `npm run build:dev` |
+| 怎么调用 | 全局 `wolf`（需先 `npm install -g .`）或 `node dist/cli/index.js` | `npm run wolf -- <command>` |
+| 默认 workspace | `~/wolf`（或 `WOLF_HOME`） | `~/wolf-dev`（或 `WOLF_DEV_HOME`） |
+| 环境变量优先级 | 只读 `WOLF_*` | 先 `WOLF_DEV_*`，fallback `WOLF_*` |
+| MCP 工具名 | `wolf_*` | `wolfdev_*` |
+| CLI banner | 无 | 每次调用都打 "dev" banner |
+| `wolf init --dev` | 拒绝，报清晰错误 | 允许 |
+
+如果你看到 `wolf init` 在向你确认是否使用你真实的 `~/wolf` 目录，说明你不小心跑了 stable build —— 请重新 `npm run build:dev`，用 `npm run wolf -- ...` 调用。
+
 ## 第四步：找一个任务来做
 
 > 开源项目的任务是公开发布的，就像游戏里的悬赏公告板——任何人都可以挑一个来做。做完提交，审核通过后，你写的代码就正式进入项目，这就是"贡献"。
@@ -222,11 +256,12 @@ git push -u origin feat/你的功能名
 
 **Dog fooding** 是一个工程术语，意思是"吃自己的狗粮"——用自己写的工具做一次真实的操作，而不只是看测试通过了就算完。
 
+请用 **dev build** 跑，这样改动会停留在你的 dev workspace（`WOLF_DEV_HOME`），用的是 dev API key。第三点五步有完整说明。
+
 ```bash
-cd /path/to/wolf      # cd 到你的 wolf 项目根目录
-npm run build         # 重新编译
-npm install -g .      # 把 wolf 安装到本地，之后才能直接用 wolf 命令
-wolf <你实现的命令>     # 真实跑一遍
+cd /path/to/wolf            # cd 到你的 wolf 项目根目录
+npm run build:dev           # 改完代码后重新编译 dev build
+npm run wolf -- <命令>       # 用 dev workspace 真实跑一遍
 ```
 
 过一遍这些问题：

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ wolf --help
 wolf mcp serve
 ```
 
+### Quick start — dev build (for contributors)
+
+If you're hacking on wolf itself, use the dev build so your code changes never touch your real `~/wolf` workspace or your production API key. See [CONTRIBUTING.md](CONTRIBUTING.md) "Step 3.5" for the full contract.
+
+```bash
+npm install
+npm run build:dev
+
+export WOLF_DEV_HOME=~/wolf-dev                # any directory you want for testing
+export WOLF_DEV_ANTHROPIC_API_KEY=sk-ant-...   # separate from your production key
+
+npm run wolf -- init --dev --empty             # create a dev workspace (no prompts)
+npm run wolf -- <command>                      # run any wolf command against the dev build
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

CONTRIBUTING used to teach contributors `npm install -g .` + a global `wolf` for both initial setup and dog-fooding — that's the **stable** build, which writes to `~/wolf` and reads the real `WOLF_ANTHROPIC_API_KEY`. A contributor following the docs would silently mix their dev work with their real job-search workspace and burn their production API budget.

This PR closes that gap end to end:

- **CONTRIBUTING.md / `_zh`**: new "Step 3.5: Use the dev build" section explaining the dev contract — `~/wolf-dev` default workspace, `WOLF_DEV_*` env precedence, dev banner on every CLI invocation, `wolfdev_*` MCP tool names, and `npm run wolf -- <command>` as the canonical dev invocation. Section opens with a TIP inviting contributors to paste it into Claude Code or ChatGPT and let the AI handle the setup, matching the doc's existing "feed this to your AI" framing.
- **CONTRIBUTING Step 8 (dog-fooding)**: switch the recommended commands from `npm run build` + `npm install -g .` + global `wolf` to `npm run build:dev` + `npm run wolf -- <command>`, so the suggested flow stays inside the dev workspace end to end.
- **README Quick start**: add a "Quick start — dev build (for contributors)" block right after the user-facing quick start, linking back to CONTRIBUTING Step 3.5 for the full table of differences.

## Why now

We just landed the AI-orchestrated test framework (#74) and the smoke / acceptance test guidance (#75). Both assume contributors are running on the dev build (`WOLF_DEV_HOME=/tmp/wolf-test/...`), but CONTRIBUTING never told them how to get there. This is the missing prerequisite.

## Files changed

- `CONTRIBUTING.md` — new Step 3.5; Step 8 dog-fooding switched to dev build
- `CONTRIBUTING_zh.md` — same in Chinese
- `README.md` — Quick start gains a dev-build subsection