### PR TITLE
docs(jsdoc): document every interface + impl; fix tsc errors in job-list test

### DIFF
--- a/src/application/addApplicationService.ts
+++ b/src/application/addApplicationService.ts
@@ -1,7 +1,20 @@
 import type { AddOptions, AddResult } from '../utils/types/index.js';
 
+/**
+ * Use case for storing a single, structured job submitted by an AI orchestrator
+ * (the MCP `wolf_add` entry point). The caller — an AI agent — has already
+ * extracted `{ title, company, jdText, url? }` from a screenshot, paste, or URL;
+ * wolf only persists, never parses raw input.
+ *
+ * Typical chain on the AI side: `wolf_add` → `wolf_score --single` → `wolf_tailor`.
+ */
 export interface AddApplicationService {
-  // Stores a structured job (extracted by an AI caller) and returns its jobId.
-  // Reuses an existing company row by name; otherwise creates one.
+  /**
+   * Stores the job. Reuses an existing company row by exact name match;
+   * otherwise creates one. Persists JD prose to disk (`jd.md`); only structured
+   * metadata goes to SQLite.
+   *
+   * @returns The new `jobId`, suitable for chaining into score / tailor.
+   */
   add(options: AddOptions): Promise<AddResult>;
 }

--- a/src/application/configApplicationService.ts
+++ b/src/application/configApplicationService.ts
@@ -1,13 +1,33 @@
+/**
+ * Result of `set` — the dot-path key that was written and the runtime-typed
+ * value that landed in `wolf.toml` after coercion. The CLI uses this to print
+ * a confirmation line.
+ */
 export interface ConfigSetResult {
   key: string;
   coerced: unknown;
 }
 
+/**
+ * Use case for `wolf config get/set` — typed dot-path access to `wolf.toml`.
+ * Reads validate that the key exists; writes coerce the input string to the
+ * target field's existing runtime shape and re-validate the whole config
+ * through Zod before persisting (with a rolling backup).
+ */
 export interface ConfigApplicationService {
-  // Reads a dot-path key from wolf.toml. Throws if the key is absent.
+  /**
+   * Reads `wolf.toml[<key>]` where `<key>` is a dot path (e.g. `tailor.model`).
+   *
+   * @throws If the key is absent — never returns `undefined`.
+   */
   get(key: string): Promise<unknown>;
 
-  // Coerces `valueStr` to the existing field's runtime shape, validates via
-  // the AppConfig schema, backs up wolf.toml, then writes.
+  /**
+   * Coerces `valueStr` to the existing field's runtime shape, validates the
+   * resulting config via the AppConfig Zod schema, backs up the current
+   * `wolf.toml` to `wolf.toml.backup1`, then writes.
+   *
+   * @throws If coercion fails or the resulting config violates the schema.
+   */
   set(key: string, valueStr: string): Promise<ConfigSetResult>;
 }

--- a/src/application/doctorApplicationService.ts
+++ b/src/application/doctorApplicationService.ts
@@ -1,6 +1,8 @@
 /**
- * Per-file readiness report. Empty `missing` array means the file is
- * "ready" by the relevant criterion.
+ * Per-file readiness check for one of the three profile markdown files.
+ * Empty `missing` array means the file is "ready" by the relevant criterion;
+ * non-empty means the user has work to do before tailor / fill / reach will
+ * run cleanly.
  */
 export interface FileCheck {
   file: string;
@@ -9,14 +11,29 @@ export interface FileCheck {
   hint: string;
 }
 
+/**
+ * Aggregate result of `wolf doctor`: one `FileCheck` per profile file plus a
+ * roll-up `ready` flag (true iff every file passes its criterion).
+ */
 export interface DoctorReport {
   profileName: string;
   checks: FileCheck[];
   ready: boolean;
 }
 
+/**
+ * Use case for `wolf doctor` — proactively reports which profile files still
+ * need user input before tailor (and downstream fill / reach when they ship)
+ * will run. Pure assessment: never modifies any file.
+ *
+ * Mirrors `assertReadyForTailor`'s checks so doctor output and tailor's
+ * runtime errors stay in sync.
+ */
 export interface DoctorApplicationService {
-  // Reads the default profile and reports which files still need user input
-  // before tailor (and downstream fill / reach when they ship) will run.
+  /**
+   * Reads the default profile and returns the readiness report.
+   * Strips `> [!IMPORTANT]` / `> [!TIP]` callout blocks before measuring
+   * field content — an unfilled template body is correctly reported empty.
+   */
   run(): Promise<DoctorReport>;
 }

--- a/src/application/envApplicationService.ts
+++ b/src/application/envApplicationService.ts
@@ -1,50 +1,92 @@
+/**
+ * One row of the `wolf env show` table: a managed key and whether it's set
+ * in the current process environment (`null` when absent).
+ */
 export interface EnvKeyStatus {
   key: string;
   value: string | null;
 }
 
+/**
+ * One match found by `wolf env clear`'s scan: a shell rc file plus the
+ * `export WOLF_*` lines inside it that will be removed.
+ */
 export interface EnvCleanupTarget {
   file: string;
   lines: string[];
 }
 
+/**
+ * Result of a non-interactive single-key write. `ok=false` carries a
+ * user-facing `error` message; `ok=true` carries the resolved rc file path.
+ */
 export interface EnvSetOneResult {
   ok: boolean;
   target?: string;
   error?: string;
 }
 
+/**
+ * Display metadata used by the interactive `wolf env set` flow to render the
+ * info page and per-key prompts.
+ */
 export interface EnvKeyInfo {
   prompt: string;
   purpose: string;
   howTo: string;
 }
 
+/**
+ * Use case for `wolf env show / set / clear` — manages `WOLF_*` API keys in
+ * the user's shell rc file. wolf intentionally avoids `.env` files because
+ * the workspace can be cloud-synced or shared with resume PDFs.
+ *
+ * The application service is stateless and has no DB / repo dependencies,
+ * so the CLI wrapper instantiates it as a module singleton (creating a full
+ * `AppContext` would force a SQLite open just to write a shell file).
+ */
 export interface EnvApplicationService {
-  // The canonical list of WOLF_* keys this build manages.
+  /** The canonical list of WOLF_* keys this build manages. */
   readonly keys: readonly string[];
 
-  // Display metadata for each key (purpose, how-to-obtain).
+  /** Display metadata for each key (purpose, how-to-obtain). */
   readonly keyInfo: Record<string, EnvKeyInfo>;
 
-  // Returns one entry per managed key with its current process.env value
-  // (or null when not set). Used by `wolf env show`.
+  /**
+   * Returns one entry per managed key with its current `process.env` value
+   * (or `null` when not set). Used by `wolf env show`.
+   */
   list(): EnvKeyStatus[];
 
-  // Detects the shell rc file to write to based on $SHELL and platform.
+  /**
+   * Detects which shell rc file to write to based on `$SHELL` and platform.
+   * Falls back to `~/.zshrc` for unrecognized shells.
+   */
   detectRcFile(): string;
 
-  // Writes the entries into the rc file's `# wolf API keys` block, updating
-  // existing exports in-place and appending the rest.
+  /**
+   * Writes the given entries into the rc file's `# wolf API keys` block.
+   * Updates existing `export WOLF_*` lines in place; appends a new block at
+   * the end for any key not already present.
+   */
   writeBlock(rcFile: string, entries: { key: string; value: string }[]): Promise<void>;
 
-  // Non-interactive single-key set. Validates the key against `keys` and the
-  // value against emptiness; writes via writeBlock on success.
+  /**
+   * Non-interactive single-key set used by `wolf env set <key> <value>`.
+   * Validates the key against `keys` and the value against emptiness;
+   * writes via `writeBlock` on success.
+   */
   setOne(key: string, value: string, rcFile?: string): Promise<EnvSetOneResult>;
 
-  // Scans every candidate rc file for `export WOLF_*` lines.
+  /**
+   * Scans every candidate rc file for `export WOLF_*` lines. Missing files
+   * are silently skipped — not every user has every rc file.
+   */
   findExports(): Promise<EnvCleanupTarget[]>;
 
-  // Rewrites each given rc file with WOLF_* export lines stripped.
+  /**
+   * Rewrites each given rc file with all `export WOLF_*` lines stripped.
+   * Other lines (comments, non-wolf exports) are preserved verbatim.
+   */
   removeExports(files: string[]): Promise<void>;
 }

--- a/src/application/fillApplicationService.ts
+++ b/src/application/fillApplicationService.ts
@@ -1,6 +1,17 @@
 import type { FillOptions, FillResult } from '../utils/types/index.js';
 
+/**
+ * Use case for `wolf fill` (Milestone 4) — Playwright-driven application form
+ * fill. Loads the Job + tailored resume/cover-letter paths via repositories,
+ * delegates form detection + submission to `FillService`, persists status +
+ * screenshot back to the job row.
+ *
+ * Currently a stub; the full pipeline lands in M4.
+ */
 export interface FillApplicationService {
-  // M4: Playwright-driven form fill + screenshot + status update.
+  /**
+   * Auto-fills the application form for `options.jobId`.
+   * Defaults to dry-run; explicit `--no-dry-run` is required to submit.
+   */
   fill(options: FillOptions): Promise<FillResult>;
 }

--- a/src/application/huntApplicationService.ts
+++ b/src/application/huntApplicationService.ts
@@ -1,6 +1,17 @@
 import type { HuntOptions, HuntResult } from '../utils/types/index.js';
 
+/**
+ * Use case for `wolf hunt` (Milestone 2) — fans out to enabled `JobProvider`s,
+ * deduplicates the results, and persists raw jobs to SQLite with `status: new`,
+ * `score: null`. Scoring is a separate command (`wolf score`).
+ *
+ * Currently a stub; the full pipeline lands in M2.
+ */
 export interface HuntApplicationService {
-  // M2: orchestrates provider fan-out, dedup, and persistence to jobRepository.
+  /**
+   * Runs every enabled provider in sequence, dedupes across providers, and
+   * inserts the new rows. Returns ingested + new counts so the CLI can show
+   * a one-line summary.
+   */
   hunt(options: HuntOptions): Promise<HuntResult>;
 }

--- a/src/application/impl/addApplicationServiceImpl.ts
+++ b/src/application/impl/addApplicationServiceImpl.ts
@@ -4,12 +4,18 @@ import type { AddOptions, AddResult } from '../../utils/types/index.js';
 import type { JobRepository } from '../../repository/jobRepository.js';
 import type { CompanyRepository } from '../../repository/companyRepository.js';
 
+/**
+ * SQLite-backed `AddApplicationService`. Looks up the company by name through
+ * `CompanyRepository`, creates one when missing, then writes the job row +
+ * JD prose via `JobRepository`.
+ */
 export class AddApplicationServiceImpl implements AddApplicationService {
   constructor(
     private readonly jobRepository: JobRepository,
     private readonly companyRepository: CompanyRepository,
   ) {}
 
+  /** @inheritdoc */
   async add(options: AddOptions): Promise<AddResult> {
     const now = new Date().toISOString();
 

--- a/src/application/impl/configApplicationServiceImpl.ts
+++ b/src/application/impl/configApplicationServiceImpl.ts
@@ -6,7 +6,13 @@ import type {
   ConfigSetResult,
 } from '../configApplicationService.js';
 
+/**
+ * File-backed `ConfigApplicationService`. Stateless — every call re-reads
+ * `wolf.toml` from the resolved workspace; writes go through `backupConfig`
+ * + `saveConfig` so the previous file is preserved as `wolf.toml.backup1`.
+ */
 export class ConfigApplicationServiceImpl implements ConfigApplicationService {
+  /** @inheritdoc */
   async get(key: string): Promise<unknown> {
     const config = await loadConfig();
     const value = getByPath(config, key);
@@ -16,6 +22,7 @@ export class ConfigApplicationServiceImpl implements ConfigApplicationService {
     return value;
   }
 
+  /** @inheritdoc */
   async set(key: string, valueStr: string): Promise<ConfigSetResult> {
     const config = await loadConfig();
     const coerced = coerceToShape(valueStr, getByPath(config, key));

--- a/src/application/impl/doctorApplicationServiceImpl.ts
+++ b/src/application/impl/doctorApplicationServiceImpl.ts
@@ -20,9 +20,17 @@ const PROFILE_REQUIRED_H2 = [
 // Minimum non-blank, non-heading lines in resume_pool.md (post-strip).
 const POOL_MIN_LINES = 5;
 
+/**
+ * `DoctorApplicationService` impl. Reads the default profile through
+ * `ProfileRepository`, runs three pure check functions (`profile.md`,
+ * `resume_pool.md`, `standard_questions.md`), and aggregates them into a
+ * `DoctorReport`. Each check strips runtime-only callouts before measuring,
+ * so unfilled templates correctly report empty.
+ */
 export class DoctorApplicationServiceImpl implements DoctorApplicationService {
   constructor(private readonly profileRepository: ProfileRepository) {}
 
+  /** @inheritdoc */
   async run(): Promise<DoctorReport> {
     const profile = await this.profileRepository.getDefault();
 

--- a/src/application/impl/envApplicationServiceImpl.ts
+++ b/src/application/impl/envApplicationServiceImpl.ts
@@ -49,14 +49,21 @@ const RC_FILES = [
 
 const WOLF_EXPORT_LINE_RE = /^export\s+WOLF_/;
 
+/**
+ * Shell-rc-backed `EnvApplicationService`. Holds the canonical `WOLF_*` key
+ * list and the rc file mutation primitives. Stateless apart from the const
+ * key registry; safe to instantiate as a module singleton.
+ */
 export class EnvApplicationServiceImpl implements EnvApplicationService {
   readonly keys = WOLF_KEYS;
   readonly keyInfo = KEY_INFO;
 
+  /** @inheritdoc */
   list(): EnvKeyStatus[] {
     return WOLF_KEYS.map((key) => ({ key, value: process.env[key] ?? null }));
   }
 
+  /** @inheritdoc */
   detectRcFile(): string {
     const shell = process.env.SHELL ?? '';
     if (shell.includes('bash')) {
@@ -67,6 +74,7 @@ export class EnvApplicationServiceImpl implements EnvApplicationService {
     return path.join(os.homedir(), '.zshrc');
   }
 
+  /** @inheritdoc */
   async writeBlock(rcFile: string, entries: { key: string; value: string }[]): Promise<void> {
     let content = '';
     try {
@@ -98,6 +106,7 @@ export class EnvApplicationServiceImpl implements EnvApplicationService {
     await fs.writeFile(rcFile, updated, 'utf-8');
   }
 
+  /** @inheritdoc */
   async setOne(key: string, value: string, rcFile?: string): Promise<EnvSetOneResult> {
     if (!(WOLF_KEYS as readonly string[]).includes(key)) {
       return { ok: false, error: `unknown key "${key}". Valid: ${WOLF_KEYS.join(', ')}` };
@@ -111,6 +120,7 @@ export class EnvApplicationServiceImpl implements EnvApplicationService {
     return { ok: true, target };
   }
 
+  /** @inheritdoc */
   async findExports(): Promise<EnvCleanupTarget[]> {
     const matches: EnvCleanupTarget[] = [];
     for (const rc of RC_FILES) {
@@ -128,6 +138,7 @@ export class EnvApplicationServiceImpl implements EnvApplicationService {
     return matches;
   }
 
+  /** @inheritdoc */
   async removeExports(files: string[]): Promise<void> {
     for (const file of files) {
       const content = await fs.readFile(file, 'utf-8');

--- a/src/application/impl/fillApplicationServiceImpl.ts
+++ b/src/application/impl/fillApplicationServiceImpl.ts
@@ -1,7 +1,14 @@
 import type { FillOptions, FillResult } from '../../utils/types/index.js';
 import type { FillApplicationService } from '../fillApplicationService.js';
 
+/**
+ * M4 stub. Throws `Not implemented` — the real implementation will compose
+ * `JobRepository`, `ProfileRepository`, and `FillService` into the form-fill
+ * pipeline. Registered in `appContext` now so M4 only needs to swap this
+ * class without re-wiring.
+ */
 export class FillApplicationServiceImpl implements FillApplicationService {
+  /** @inheritdoc */
   async fill(_options: FillOptions): Promise<FillResult> {
     throw new Error('Not implemented');
   }

--- a/src/application/impl/huntApplicationServiceImpl.ts
+++ b/src/application/impl/huntApplicationServiceImpl.ts
@@ -1,7 +1,13 @@
 import type { HuntOptions, HuntResult } from '../../utils/types/index.js';
 import type { HuntApplicationService } from '../huntApplicationService.js';
 
+/**
+ * M2 stub. Throws `Not implemented` — the real implementation will compose
+ * the `JobProvider` registry, dedup logic, and `JobRepository.saveMany`.
+ * Registered in `appContext` now so M2 only needs to swap this class.
+ */
 export class HuntApplicationServiceImpl implements HuntApplicationService {
+  /** @inheritdoc */
   async hunt(_options: HuntOptions): Promise<HuntResult> {
     throw new Error('Not implemented');
   }

--- a/src/application/impl/initApplicationServiceImpl.ts
+++ b/src/application/impl/initApplicationServiceImpl.ts
@@ -14,9 +14,16 @@ import type {
 
 const DEFAULT_PROFILE_NAME = 'default';
 
+/**
+ * `InitApplicationService` impl. Owns the bundled markdown templates
+ * (imported as raw strings via tsup's `.md` loader) and the workspace
+ * skeleton writer. No DB / repo deps — safe to instantiate as a module
+ * singleton.
+ */
 export class InitApplicationServiceImpl implements InitApplicationService {
   readonly defaultProfileName = DEFAULT_PROFILE_NAME;
 
+  /** @inheritdoc */
   buildDefaultConfig(mode?: 'stable' | 'dev'): AppConfig {
     return {
       ...(mode ? { instance: { mode } } : {}),
@@ -29,6 +36,7 @@ export class InitApplicationServiceImpl implements InitApplicationService {
     };
   }
 
+  /** @inheritdoc */
   async writeWorkspace(options: WriteWorkspaceOptions): Promise<void> {
     const { workspaceDir, config, overwriteConfig } = options;
     await fs.mkdir(workspaceDir, { recursive: true });

--- a/src/application/impl/jobApplicationServiceImpl.ts
+++ b/src/application/impl/jobApplicationServiceImpl.ts
@@ -9,12 +9,19 @@ import type { JobRepository } from '../../repository/jobRepository.js';
 import type { CompanyRepository } from '../../repository/companyRepository.js';
 import type { JobApplicationService } from '../jobApplicationService.js';
 
+/**
+ * SQLite-backed `JobApplicationService`. Runs `query` and `countMatching`
+ * in parallel through `JobRepository` so the overflow footer stays accurate
+ * without adding user-visible latency. Caches company-name lookups per call
+ * to guard against N+1 against `CompanyRepository`.
+ */
 export class JobApplicationServiceImpl implements JobApplicationService {
   constructor(
     private readonly jobRepository: JobRepository,
     private readonly companyRepository: CompanyRepository,
   ) {}
 
+  /** @inheritdoc */
   async list(options: JobListOptions): Promise<JobListResult> {
     const opts = validateAndNormalize(options);
 

--- a/src/application/impl/profileApplicationServiceImpl.ts
+++ b/src/application/impl/profileApplicationServiceImpl.ts
@@ -39,7 +39,13 @@ async function dirExists(dir: string): Promise<boolean> {
   }
 }
 
+/**
+ * Filesystem-backed `ProfileApplicationService`. Operates directly on
+ * `profiles/<name>/` directories under the resolved workspace and on
+ * `wolf.toml.default`. No DB / repo deps; all I/O is through node's `fs`.
+ */
 export class ProfileApplicationServiceImpl implements ProfileApplicationService {
+  /** @inheritdoc */
   async list(): Promise<ProfileListResult> {
     const profilesDir = path.join(resolveWorkspaceDir(), 'profiles');
     let entries: string[] = [];
@@ -68,6 +74,7 @@ export class ProfileApplicationServiceImpl implements ProfileApplicationService 
     return { kind: 'ok', profiles };
   }
 
+  /** @inheritdoc */
   async create(name: string, opts: { from?: string } = {}): Promise<ProfileCreateResult> {
     assertValidProfileName(name);
 
@@ -106,6 +113,7 @@ export class ProfileApplicationServiceImpl implements ProfileApplicationService 
     return { name, from: srcName, targetDir };
   }
 
+  /** @inheritdoc */
   async use(name: string): Promise<void> {
     const targetDir = profileDir(name);
     if (!(await dirExists(targetDir))) {
@@ -118,6 +126,7 @@ export class ProfileApplicationServiceImpl implements ProfileApplicationService 
     await saveConfig(updated);
   }
 
+  /** @inheritdoc */
   async delete(name: string, opts: { yes?: boolean } = {}): Promise<string> {
     const config = await loadConfig();
     if (name === config.default) {

--- a/src/application/impl/reachApplicationServiceImpl.ts
+++ b/src/application/impl/reachApplicationServiceImpl.ts
@@ -1,7 +1,14 @@
 import type { ReachOptions, ReachResult } from '../../utils/types/index.js';
 import type { ReachApplicationService } from '../reachApplicationService.js';
 
+/**
+ * M5 stub. Throws `Not implemented` — the real implementation will compose
+ * a contact-lookup provider, the Claude email-draft prompt, and `.eml` /
+ * `.md` writers. Registered in `appContext` now so M5 only needs to swap
+ * this class.
+ */
 export class ReachApplicationServiceImpl implements ReachApplicationService {
+  /** @inheritdoc */
   async reach(_options: ReachOptions): Promise<ReachResult> {
     throw new Error('Not implemented');
   }

--- a/src/application/impl/scoreApplicationServiceImpl.ts
+++ b/src/application/impl/scoreApplicationServiceImpl.ts
@@ -1,7 +1,13 @@
 import type { ScoreOptions, ScoreResult } from '../../utils/types/index.js';
 import type { ScoreApplicationService } from '../scoreApplicationService.js';
 
+/**
+ * M2 stub. Throws `Not implemented` — the real implementation will compose
+ * AI field extraction, dealbreaker checks, and `BatchService.submit`.
+ * Registered in `appContext` now so M2 only needs to swap this class.
+ */
 export class ScoreApplicationServiceImpl implements ScoreApplicationService {
+  /** @inheritdoc */
   async score(_options: ScoreOptions): Promise<ScoreResult> {
     throw new Error('Not implemented');
   }

--- a/src/application/impl/statusApplicationServiceImpl.ts
+++ b/src/application/impl/statusApplicationServiceImpl.ts
@@ -18,6 +18,7 @@ export class StatusApplicationServiceImpl implements StatusApplicationService {
     private readonly counters: StatusCounter[],
   ) {}
 
+  /** @inheritdoc */
   async getSummary(): Promise<StatusSummary> {
     const counters = await Promise.all(
       this.counters.map(async ({ label, count }): Promise<StatusCount> => {

--- a/src/application/impl/tailorApplicationServiceImpl.ts
+++ b/src/application/impl/tailorApplicationServiceImpl.ts
@@ -57,6 +57,13 @@ interface JobContext {
   coverLetterPdfPath: string;
 }
 
+/**
+ * Default `TailorApplicationService` impl. Composes the analyst brief
+ * service, the resume + cover-letter writers, and the PDF render service
+ * around `JobRepository` + `ProfileRepository`. Calls `assertReadyForTailor`
+ * before any AI invocation so a placeholder profile or empty pool surfaces
+ * a typed error instead of a hallucinated resume.
+ */
 export class TailorApplicationServiceImpl implements TailorApplicationService {
   constructor(
     private readonly jobRepository: JobRepository,
@@ -68,6 +75,7 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
     private readonly defaultCoverLetterTone: string,
   ) {}
 
+  /** @inheritdoc */
   async tailor(options: TailorOptions): Promise<TailorResult> {
     // Resolve job/profile/paths once; every step below works against this context.
     const ctx = await this.prepareContext(options);
@@ -132,6 +140,7 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
     };
   }
 
+  /** @inheritdoc */
   async analyze(options: TailorOptions): Promise<AnalyzeResult> {
     const ctx = await this.prepareContext(options);
     await this.ensureHintFile(ctx.hintPath, options.hint);
@@ -139,6 +148,7 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
     return { briefPath: ctx.briefPath };
   }
 
+  /** @inheritdoc */
   async writeResume(options: TailorOptions): Promise<WriteStepResult> {
     const ctx = await this.prepareContext(options);
     const brief = await this.readBrief(ctx);
@@ -147,6 +157,7 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
     return step;
   }
 
+  /** @inheritdoc */
   async writeCoverLetter(options: TailorOptions): Promise<WriteStepResult> {
     const ctx = await this.prepareContext(options);
     const brief = await this.readBrief(ctx);

--- a/src/application/initApplicationService.ts
+++ b/src/application/initApplicationService.ts
@@ -1,21 +1,42 @@
 import type { AppConfig } from '../utils/types/index.js';
 
+/**
+ * Arguments for `writeWorkspace`. `overwriteConfig=true` replaces an existing
+ * `wolf.toml` after backing it up; `false` preserves whatever is on disk.
+ */
 export interface WriteWorkspaceOptions {
   workspaceDir: string;
   config: AppConfig;
   overwriteConfig: boolean;
 }
 
+/**
+ * Use case for `wolf init` — lays down a fresh wolf workspace skeleton.
+ * Idempotent: existing files are preserved (template files won't clobber
+ * user edits) unless `overwriteConfig` is set, in which case `wolf.toml` is
+ * replaced after a backup.
+ *
+ * Important: this service runs **before** `wolf.toml` exists, which means
+ * it cannot live behind a fully-wired `AppContext` (createAppContext loads
+ * the toml synchronously). The CLI wrapper instantiates it as a module
+ * singleton.
+ */
 export interface InitApplicationService {
-  // Builds the default AppConfig used by `wolf init`. Caller passes the
-  // build mode so the dev marker can be embedded when applicable.
+  /**
+   * Builds the default `AppConfig` used by `wolf init`. Caller passes the
+   * build mode so the dev marker (`instance.mode = "dev"`) is embedded only
+   * when applicable.
+   */
   buildDefaultConfig(mode?: 'stable' | 'dev'): AppConfig;
 
-  // Lays down a fresh workspace skeleton: wolf.toml + default profile dir +
-  // data/ + .gitignore + AI agent instructions. Idempotent: existing files
-  // are preserved unless overwriteConfig is true.
+  /**
+   * Lays down the workspace skeleton: `wolf.toml`, default profile dir
+   * (with the four template MD files + `attachments/`), `data/`,
+   * `.gitignore`, and `CLAUDE.md` / `AGENTS.md`. Each file is written
+   * only if absent, except `wolf.toml` when `overwriteConfig=true`.
+   */
   writeWorkspace(options: WriteWorkspaceOptions): Promise<void>;
 
-  // The conventional name of the default profile directory.
+  /** The conventional name of the default profile directory (`"default"`). */
   readonly defaultProfileName: string;
 }

--- a/src/application/jobApplicationService.ts
+++ b/src/application/jobApplicationService.ts
@@ -1,8 +1,17 @@
 import type { JobListOptions, JobListResult } from '../utils/types/commands.js';
 
+/**
+ * Use case for `wolf job list` — the filtered job listing. Validates raw
+ * CLI input at the application boundary (rejects bad `--status`, NaN
+ * `--min-score`, unparseable `--start` / `--end`, non-positive `--limit`),
+ * runs the filter as a single SQL query, and resolves company names for
+ * display with a per-call cache.
+ */
 export interface JobApplicationService {
-  // Validates and normalizes raw CLI options, then delegates to the
-  // jobRepository to run the filtered list query and resolve company
-  // names for display.
+  /**
+   * Returns matching jobs (with display-resolved company names) plus the
+   * unlimited `totalMatching` count. The CLI uses `totalMatching` to render
+   * the overflow footer (`... N more — use --limit`).
+   */
   list(options: JobListOptions): Promise<JobListResult>;
 }

--- a/src/application/profileApplicationService.ts
+++ b/src/application/profileApplicationService.ts
@@ -1,32 +1,66 @@
+/**
+ * One row of the `wolf profile list` output.
+ */
 export interface ProfileEntry {
   name: string;
   isDefault: boolean;
 }
 
+/**
+ * `list()` result — distinguishes "no profiles dir at all" (run `wolf init`),
+ * "dir exists but empty" (run `wolf profile create`), and the populated case.
+ * The CLI wrapper picks the right user-facing message off `kind`.
+ */
 export type ProfileListResult =
   | { kind: 'no-profiles-dir' }
   | { kind: 'empty' }
   | { kind: 'ok'; profiles: ProfileEntry[] };
 
+/**
+ * `create()` result — the new profile name, the source it cloned from
+ * (default unless `--from` was given), and the absolute target dir for
+ * the success message.
+ */
 export interface ProfileCreateResult {
   name: string;
   from: string;
   targetDir: string;
 }
 
+/**
+ * Use case for `wolf profile list / create / use / delete` — manages the
+ * `profiles/<name>/` directories under the workspace and the `default`
+ * pointer in `wolf.toml`.
+ */
 export interface ProfileApplicationService {
-  // Returns the profiles found under profiles/ and which one is the default.
+  /**
+   * Lists profile directories with the default flagged. Returns a tagged
+   * union so the CLI can render different messages without re-checking
+   * filesystem state.
+   */
   list(): Promise<ProfileListResult>;
 
-  // Clones the source profile (default unless `from` is given) into a new
-  // profiles/<name>/ directory.
+  /**
+   * Clones the source profile (the default unless `opts.from` is given)
+   * into a new `profiles/<name>/`. Validates the name (filesystem-safe),
+   * refuses to overwrite an existing directory, copies all four MD files
+   * + `attachments/`.
+   *
+   * @throws If the name is invalid, the target exists, or the source is missing.
+   */
   create(name: string, opts?: { from?: string }): Promise<ProfileCreateResult>;
 
-  // Switches the default profile pointer in wolf.toml. Verifies the target
-  // directory exists first.
+  /**
+   * Switches the default profile by updating `wolf.toml.default`. Verifies
+   * the target directory exists first — refuses to set the pointer to a
+   * profile that won't resolve.
+   */
   use(name: string): Promise<void>;
 
-  // Removes a profile directory. Refuses to delete the current default and
-  // requires opts.yes for safety.
+  /**
+   * Removes a profile directory. Refuses to delete the current default
+   * (switch first via `use`); requires `opts.yes=true` for safety; returns
+   * the deleted directory path for the success message.
+   */
   delete(name: string, opts?: { yes?: boolean }): Promise<string>;
 }

--- a/src/application/reachApplicationService.ts
+++ b/src/application/reachApplicationService.ts
@@ -1,6 +1,18 @@
 import type { ReachOptions, ReachResult } from '../utils/types/index.js';
 
+/**
+ * Use case for `wolf reach` (Milestone 5) — finds HR contacts for a job and
+ * drafts an outreach email. Output is two files: a `.eml` (double-clickable
+ * into the system mail client) and a `.md` (pastable into Gmail web or
+ * LinkedIn InMail). **wolf does NOT send** — the user keeps send authority.
+ *
+ * Currently a stub; the full pipeline lands in M5.
+ */
 export interface ReachApplicationService {
-  // M5: contact lookup + email draft (.eml + .md). wolf does NOT send.
+  /**
+   * Resolves contacts via the configured provider, drafts the email body
+   * with Claude, writes both file shapes, persists `outreachDraftPath`
+   * back to the job row.
+   */
   reach(options: ReachOptions): Promise<ReachResult>;
 }

--- a/src/application/scoreApplicationService.ts
+++ b/src/application/scoreApplicationService.ts
@@ -1,6 +1,18 @@
 import type { ScoreOptions, ScoreResult } from '../utils/types/index.js';
 
+/**
+ * Use case for `wolf score` (Milestone 2) — processes unscored jobs:
+ * AI extraction of structured fields (sponsorship / tech stack / remote /
+ * salary), dealbreaker filters, then submission to Claude Batch API for
+ * async scoring. `--single` switches to synchronous Haiku for one job.
+ *
+ * Currently a stub; the full pipeline lands in M2.
+ */
 export interface ScoreApplicationService {
-  // M2: AI extraction + dealbreaker filters + Batch API submission.
+  /**
+   * Scans for jobs with `score: null`, extracts fields, applies hard filters
+   * (filtered → `status: filtered`), submits the rest to Batch API. Returns
+   * batch id + counts for the CLI summary.
+   */
   score(options: ScoreOptions): Promise<ScoreResult>;
 }

--- a/src/application/tailorApplicationService.ts
+++ b/src/application/tailorApplicationService.ts
@@ -1,14 +1,25 @@
 import type { TailorOptions, TailorResult } from '../utils/types/index.js';
 
+/** Result of the brief step — the absolute path to `tailoring-brief.md`. */
 export interface AnalyzeResult {
   briefPath: string;
 }
 
+/** Result of a writer step (resume or cover letter) — the rendered HTML + PDF. */
 export interface WriteStepResult {
   htmlPath: string;
   pdfPath: string;
 }
 
+/**
+ * Use case for `wolf tailor` — the 3-agent checkpoint pipeline that takes
+ * a `(profile, resume_pool, JD)` triple and produces a tailored resume +
+ * cover letter as both HTML (editable checkpoint) and PDF (final).
+ *
+ * The pipeline is exposed both as a one-shot (`tailor`) and as discrete
+ * steps (`analyze` → `writeResume` / `writeCoverLetter`) so users can
+ * inspect or hand-edit `tailoring-brief.md` before the writers run.
+ */
 export interface TailorApplicationService {
   /**
    * Full pipeline: analyze -> brief -> (resume + cover letter in parallel).

--- a/src/cli/commands/__tests__/job-list.test.ts
+++ b/src/cli/commands/__tests__/job-list.test.ts
@@ -327,12 +327,12 @@ describe('runJobListCli()', () => {
     expect(process.exitCode).toBe(1);
 
     // The user-facing message must be on stderr and must name the bad flag.
-    const errCalls = errSpy.mock.calls.map((c) => String(c[0]));
-    expect(errCalls.some((s) => s.includes('Invalid --status "nonsense"'))).toBe(true);
+    const errCalls = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(errCalls.some((s: string) => s.includes('Invalid --status "nonsense"'))).toBe(true);
 
     // Stack frames look like `    at <fn> (...)` — the whole point of the
     // fix is that this noise must not appear anywhere in our output.
-    const allOut = [...errCalls, ...logSpy.mock.calls.map((c) => String(c[0]))].join('\n');
+    const allOut = [...errCalls, ...logSpy.mock.calls.map((c: unknown[]) => String(c[0]))].join('\n');
     expect(allOut).not.toMatch(/^\s+at\s/m);
 
     // No success row may be printed when validation fails.
@@ -353,7 +353,7 @@ describe('runJobListCli()', () => {
     expect(process.exitCode).toBe(0);
     expect(errSpy).not.toHaveBeenCalled();
     // Table output: header line + at least one data row containing the job.
-    const stdout = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    const stdout = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(stdout).toMatch(/^ID\s+COMPANY\s+TITLE\s+STATUS\s+SCORE/m);
     expect(stdout).toContain('Acme');
     expect(stdout).toContain('SWE');
@@ -371,7 +371,7 @@ describe('runJobListCli()', () => {
     await runJobListCli({}, true, ctx);
 
     expect(process.exitCode).toBe(0);
-    const stdout = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    const stdout = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     // Must parse as JSON and carry the expected shape.
     const parsed = JSON.parse(stdout);
     expect(parsed.jobs).toHaveLength(1);

--- a/src/repository/batchRepository.ts
+++ b/src/repository/batchRepository.ts
@@ -1,21 +1,39 @@
+/** What this batch is for — drives the result handler that runs on completion. */
 export type BatchType = "score" | "tailor";
+
+/** AI provider behind the batch. Different providers expose different APIs. */
 export type BatchAiProvider = "anthropic" | "openai";
+
+/** Lifecycle state for a batch row. */
 export type BatchStatus = "pending" | "completed" | "failed";
 
+/** One row in the `batches` table. */
 export interface Batch {
   id: string;
-  batchId: string;        // external ID from AI provider
+  /** External ID returned by the AI provider on submit. */
+  batchId: string;
   type: BatchType;
   aiProvider: BatchAiProvider;
   profileId: string;
   status: BatchStatus;
-  submittedAt: string;    // ISO 8601
+  /** ISO 8601 — when wolf submitted the batch. */
+  submittedAt: string;
+  /** ISO 8601 — when the provider reported completion; null while pending. */
   completedAt: string | null;
 }
 
+/**
+ * Repository for AI batch metadata. Generic on purpose so any future
+ * batch-driven workflow (scoring, tailoring, …) reuses the same storage and
+ * polling machinery rather than each command minting its own.
+ */
 export interface BatchRepository {
+  /** Inserts or replaces the batch row by `id`. */
   save(batch: Batch): Promise<void>;
+  /** Returns every batch still in `pending` state. */
   getPending(): Promise<Batch[]>;
+  /** Marks a batch complete and stamps `completedAt`. */
   markComplete(id: string, completedAt: string): Promise<void>;
+  /** Marks a batch failed (terminal state — no retry by design). */
   markFailed(id: string): Promise<void>;
 }

--- a/src/repository/companyRepository.ts
+++ b/src/repository/companyRepository.ts
@@ -1,10 +1,20 @@
 import type { Company, CompanyQuery, CompanyUpdate } from "../utils/types/company.js";
 
+/**
+ * Repository for the `companies` table plus per-company workspace files.
+ * Companies are first-class entities (multiple jobs share one row); the
+ * `reach` flow uses domain + LinkedIn URL to draft outreach.
+ */
 export interface CompanyRepository {
+  /** Fetches one company by id, or `null` if missing. */
   get(id: string): Promise<Company | null>;
+  /** Looks up a company by exact name match (case-sensitive). */
   getByName(name: string): Promise<Company | null>;
+  /** Inserts or updates a company row keyed on `id`. */
   upsert(company: Company): Promise<void>;
+  /** Partial update — touches only the fields named in `patch`. */
   update(id: string, patch: CompanyUpdate): Promise<void>;
+  /** Filtered list query. Empty `q` returns every row. */
   query(q: CompanyQuery): Promise<Company[]>;
 
   /**

--- a/src/repository/impl/inMemoryProfileRepositoryImpl.ts
+++ b/src/repository/impl/inMemoryProfileRepositoryImpl.ts
@@ -14,6 +14,12 @@ const MOCK_PROFILE: Profile = {
   md: MOCK_PROFILE_MD,
 };
 
+/**
+ * Test-only `ProfileRepository`. Returns a single mock profile named
+ * `default` with just enough content to pass the "non-empty profile.md"
+ * contract. Tests that need richer fixtures should construct their own
+ * repo or `Profile` rather than extending this.
+ */
 export class InMemoryProfileRepositoryImpl implements ProfileRepository {
   async get(name: string): Promise<Profile | null> {
     return name === MOCK_NAME ? MOCK_PROFILE : null;

--- a/src/repository/impl/sqliteBatchRepositoryImpl.ts
+++ b/src/repository/impl/sqliteBatchRepositoryImpl.ts
@@ -3,13 +3,20 @@ import type { BatchRepository, Batch } from '../batchRepository.js';
 import type { DrizzleDb } from './drizzleDb.js';
 import { batches } from './schema.js';
 
+/**
+ * Drizzle/SQLite-backed `BatchRepository`. Stores AI batch metadata in the
+ * `batches` table; pending rows survive process restarts so polling can
+ * resume after a crash.
+ */
 export class SqliteBatchRepositoryImpl implements BatchRepository {
   constructor(private readonly db: DrizzleDb) {}
 
+  /** @inheritdoc */
   async save(batch: Batch): Promise<void> {
     await this.db.insert(batches).values(batchToRow(batch));
   }
 
+  /** @inheritdoc */
   async getPending(): Promise<Batch[]> {
     const rows = await this.db
       .select()
@@ -18,6 +25,7 @@ export class SqliteBatchRepositoryImpl implements BatchRepository {
     return rows.map(rowToBatch);
   }
 
+  /** @inheritdoc */
   async markComplete(id: string, completedAt: string): Promise<void> {
     await this.db
       .update(batches)
@@ -25,6 +33,7 @@ export class SqliteBatchRepositoryImpl implements BatchRepository {
       .where(eq(batches.id, id));
   }
 
+  /** @inheritdoc */
   async markFailed(id: string): Promise<void> {
     await this.db
       .update(batches)

--- a/src/repository/jobRepository.ts
+++ b/src/repository/jobRepository.ts
@@ -1,12 +1,26 @@
 import type { Job, JobQuery, JobStatus, JobUpdate } from "../utils/types/job.js";
 
+/**
+ * Repository for the `jobs` table plus per-job workspace files. SQLite
+ * holds structured metadata only; free-form prose (JD text, screenshots,
+ * tailoring brief, rendered HTML/PDF) lives on disk under
+ * `data/jobs/<company>_<title>_<jobIdShort>/` so the workspace is
+ * grep-friendly and hand-editable.
+ */
 export interface JobRepository {
+  /** Fetches one job by id, or `null` if missing. */
   get(id: string): Promise<Job | null>;
+  /** Inserts or replaces a job row by `id`. */
   save(job: Job): Promise<void>;
+  /** Bulk variant — wraps `save` in a single transaction for hunt ingestion. */
   saveMany(jobs: Job[]): Promise<void>;
+  /** Filtered list query honoring `limit`. */
   query(q: JobQuery): Promise<Job[]>;
+  /** Partial update — touches only the fields named in `patch`. */
   update(id: string, patch: JobUpdate): Promise<void>;
+  /** Bulk partial update — same `patch` applied to every id. */
   updateMany(ids: string[], patch: JobUpdate): Promise<void>;
+  /** Counts grouped by status, e.g. `{ new: 12, applied: 3, … }`. */
   countByStatus(): Promise<Record<JobStatus, number>>;
 
   /** Total number of jobs in the DB, regardless of status. */
@@ -21,6 +35,7 @@ export interface JobRepository {
   /** Total number of rows matching a query, ignoring the query's `limit`. */
   countMatching(q: JobQuery): Promise<number>;
 
+  /** Removes the job row. Workspace files on disk are NOT touched. */
   delete(id: string): Promise<void>;
 
   /**

--- a/src/service/batchService.ts
+++ b/src/service/batchService.ts
@@ -1,9 +1,13 @@
 import type { Job } from '../utils/types/index.js';
 import type { Profile } from '../utils/types/index.js';
 
+/** What a batch is doing — drives the result handler that runs on completion. */
 export type BatchType = 'score' | 'tailor';
+
+/** AI provider behind the batch. Different providers expose different APIs. */
 export type BatchAiProvider = 'anthropic' | 'openai';
 
+/** Submit-time arguments. `profileId` is recorded so the result handler can rehydrate context. */
 export interface BatchSubmitOptions {
   type: BatchType;
   aiProvider: BatchAiProvider;
@@ -11,6 +15,12 @@ export interface BatchSubmitOptions {
   profileId: string;
 }
 
+/**
+ * Domain service for AI batch jobs. Hides the provider-specific submission
+ * and polling APIs behind a uniform interface and persists every batch's
+ * status to the `batches` table via `BatchRepository` so a process restart
+ * doesn't lose track of in-flight work.
+ */
 export interface BatchService {
   /** Submit jobs to the AI provider batch API. Returns the internal batch id. */
   submit(jobs: Job[], options: BatchSubmitOptions): Promise<string>;

--- a/src/service/fillService.ts
+++ b/src/service/fillService.ts
@@ -1,5 +1,11 @@
 import type { FillOptions, FillResult } from '../utils/types/index.js';
 
+/**
+ * Domain service for `wolf fill` (Milestone 4). Hides the Playwright
+ * machinery — page navigation, field detection, mapping detected fields
+ * to profile data, screenshot capture — behind a single `run` call.
+ * Currently a stub; full implementation lands in M4.
+ */
 export interface FillService {
   // M4 entry point: Playwright-driven form fill. Reads JD URL + tailored
   // resume/cover-letter paths from the job row, navigates the page, maps

--- a/src/service/impl/apiJobProviderImpl.ts
+++ b/src/service/impl/apiJobProviderImpl.ts
@@ -1,5 +1,11 @@
 import type { JobProvider, RawJob } from '../jobProvider.js';
 
+/**
+ * Configuration for a generic HTTP-API provider. The whole point is that
+ * users can point wolf at any JSON-returning endpoint without writing a
+ * provider class — AI-driven field extraction normalizes the response
+ * downstream.
+ */
 export interface ApiProviderConfig {
   name: string;
   url: string;
@@ -8,6 +14,12 @@ export interface ApiProviderConfig {
   body?: string;
 }
 
+/**
+ * Generic HTTP-API `JobProvider`. Accepts either a JSON array directly or
+ * a wrapper object with a single array-valued field (the common shape for
+ * paginated APIs). Anything else throws so misconfigured endpoints fail
+ * loudly instead of silently returning zero jobs.
+ */
 export class ApiJobProviderImpl implements JobProvider {
   readonly name: string;
   private readonly config: ApiProviderConfig;
@@ -17,6 +29,7 @@ export class ApiJobProviderImpl implements JobProvider {
     this.config = config;
   }
 
+  /** @inheritdoc */
   async fetch(): Promise<RawJob[]> {
     const method = this.config.method ?? 'GET';
 

--- a/src/service/impl/batchServiceImpl.ts
+++ b/src/service/impl/batchServiceImpl.ts
@@ -3,16 +3,24 @@ import type { BatchRepository } from '../../repository/batchRepository.js';
 import type { JobRepository } from '../../repository/jobRepository.js';
 import type { Job } from '../../utils/types/index.js';
 
+/**
+ * Default `BatchService` impl. Stub until M3+: real implementation lives on
+ * `dev/v0.3:src/utils/batch.ts` and will be ported here once the Batch API
+ * scoring path lands. Persists batch metadata via `BatchRepository`; reads
+ * Job rows back through `JobRepository` to attach scoring results.
+ */
 export class BatchServiceImpl implements BatchService {
   constructor(
     private readonly batchRepo: BatchRepository,
     private readonly jobRepo: JobRepository,
   ) {}
 
+  /** @inheritdoc */
   async submit(_jobs: Job[], _options: BatchSubmitOptions): Promise<string> {
     throw new Error('Not implemented (M3+) — see dev/v0.3:src/utils/batch.ts for reference');
   }
 
+  /** @inheritdoc */
   async pollAll(): Promise<void> {
     throw new Error('Not implemented (M3+) — see dev/v0.3:src/utils/batch.ts for reference');
   }

--- a/src/service/impl/fillServiceImpl.ts
+++ b/src/service/impl/fillServiceImpl.ts
@@ -1,7 +1,14 @@
 import type { FillOptions, FillResult } from '../../utils/types/index.js';
 import type { FillService } from '../fillService.js';
 
+/**
+ * M4 stub. Throws `Not implemented` — the real impl will use Playwright
+ * to load `job.url`, detect form fields, map them to the profile, fill,
+ * and (when not dry-run) submit. Wired through `appContext` now so M4
+ * only needs to swap this class.
+ */
 export class FillServiceImpl implements FillService {
+  /** @inheritdoc */
   async run(_options: FillOptions): Promise<FillResult> {
     throw new Error('Not implemented');
   }

--- a/src/service/impl/renderServiceImpl.ts
+++ b/src/service/impl/renderServiceImpl.ts
@@ -9,7 +9,14 @@ import type { RenderService } from '../renderService.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SHELL_PATH = path.join(__dirname, 'render', 'shell.html');
 
+/**
+ * Playwright-backed `RenderService`. Routes to two distinct pipelines —
+ * `fit()`-driven resume rendering with binary-search CSS sizing, and
+ * natural-layout cover-letter rendering. Both inject the body into
+ * `shell.html`'s `#resume-root` so styling is centralized.
+ */
 export class RenderServiceImpl implements RenderService {
+  /** @inheritdoc */
   async renderPdf(htmlBody: string): Promise<Buffer> {
     // Resume rendering is a one-page fit job: shrink-to-fit when content
     // overflows, expand-to-fill when it underflows, throwing CannotFitError
@@ -17,6 +24,7 @@ export class RenderServiceImpl implements RenderService {
     return renderResumePdfFit(htmlBody);
   }
 
+  /** @inheritdoc */
   async renderCoverLetterPdf(htmlBody: string): Promise<Buffer> {
     // Cover letters render at natural CSS-driven layout. No fit loop —
     // short content keeps its bottom whitespace, long content paginates

--- a/src/service/impl/resumeCoverLetterServiceImpl.ts
+++ b/src/service/impl/resumeCoverLetterServiceImpl.ts
@@ -6,7 +6,14 @@ import COVER_LETTER_SYSTEM_PROMPT from './prompts/cover-letter-system.md';
 import type { ResumeCoverLetterService } from '../resumeCoverLetterService.js';
 import type { AiConfig, Profile } from '../../utils/types/index.js';
 
+/**
+ * Anthropic-backed `ResumeCoverLetterService`. Loads the prompts bundled
+ * under `service/impl/prompts/`, fills them with `(pool, jd, profile, brief)`,
+ * calls `aiClient`, and returns the raw HTML body. Empty AI responses throw
+ * rather than silently rendering a blank PDF.
+ */
 export class ResumeCoverLetterServiceImpl implements ResumeCoverLetterService {
+  /** @inheritdoc */
   async tailorResumeToHtml(
     resumePool: string,
     jdText: string,
@@ -46,6 +53,7 @@ export class ResumeCoverLetterServiceImpl implements ResumeCoverLetterService {
     return validateAndLogOrThrow(raw, 'resume', profile.name);
   }
 
+  /** @inheritdoc */
   async generateCoverLetter(
     resumePool: string,
     jdText: string,

--- a/src/service/impl/tailoringBriefServiceImpl.ts
+++ b/src/service/impl/tailoringBriefServiceImpl.ts
@@ -5,7 +5,15 @@ import ANALYST_SYSTEM_PROMPT from './prompts/analyst-system.md';
 import type { TailoringBriefService } from '../tailoringBriefService.js';
 import type { AiConfig, Profile } from '../../utils/types/index.js';
 
+/**
+ * Anthropic-backed `TailoringBriefService`. Loads the analyst system prompt
+ * from `service/impl/prompts/analyst-system.md`, calls `aiClient`, and
+ * returns the brief markdown. Strips template callouts from the profile
+ * before feeding it to the model and treats user `hint` text as an
+ * authoritative override injected under `## User Guidance`.
+ */
 export class TailoringBriefServiceImpl implements TailoringBriefService {
+  /** @inheritdoc */
   async analyze(
     resumePool: string,
     jdText: string,

--- a/src/service/jobProvider.ts
+++ b/src/service/jobProvider.ts
@@ -1,7 +1,19 @@
 /** Raw job data returned by a provider — structure varies by source. */
 export type RawJob = Record<string, unknown>;
 
+/**
+ * Pluggable source of job listings. Implementations wrap a single channel
+ * (a JSON HTTP endpoint, an email parser, an AI-driven browser session, a
+ * manual paste). `wolf hunt` fans out across every enabled provider, dedupes
+ * the union, and persists the result. Extending wolf to a new job source =
+ * adding one more class implementing this interface.
+ */
 export interface JobProvider {
+  /** Display name used in logs and dedup conflict messages. */
   readonly name: string;
+  /**
+   * Fetches the current listings from this source. The shape is intentionally
+   * loose — wolf relies on AI-driven extraction downstream to normalize.
+   */
   fetch(): Promise<RawJob[]>;
 }

--- a/src/service/renderService.ts
+++ b/src/service/renderService.ts
@@ -1,5 +1,11 @@
 import type { CannotFitError, CannotFillError } from './impl/render/fit.js';
 
+/**
+ * Domain service for HTML → PDF rendering. Two pipelines: a fit-loop
+ * resume renderer that binary-searches CSS sizing until the content fills
+ * exactly one page, and a natural-layout cover-letter renderer that
+ * preserves whitespace and paginates organically.
+ */
 export interface RenderService {
   /**
    * Render HTML body content to a one-page PDF via Playwright + fit algorithm.

--- a/src/service/resumeCoverLetterService.ts
+++ b/src/service/resumeCoverLetterService.ts
@@ -1,5 +1,11 @@
 import type { AiConfig, Profile } from '../utils/types/index.js';
 
+/**
+ * Domain service for the two writer agents in the tailor pipeline. Both
+ * agents receive the analyst's tailoring brief and produce HTML bodies
+ * (`#resume-root` payload) — the resume writer is fit-constrained, the
+ * cover-letter writer is free-form.
+ */
 export interface ResumeCoverLetterService {
   /**
    * Select and rewrite resume content to match a job description, guided by the analyst's brief.


### PR DESCRIPTION
## Summary
- Add JSDoc to every interface (`*ApplicationService`, `*Service`, `*Repository`) and every implementation (`*Impl`) across application / service / repository layers — 42 files touched
- Fix the 5 pre-existing TS7006 errors in `src/cli/commands/__tests__/job-list.test.ts` (typed the `(c) =>` / `(s) =>` callbacks in `mock.calls.map`/`some` chains)

JSDoc style:
- Interfaces get a top block describing purpose, contract, and key invariants
- Implementations get a top block naming the backing technology + nontrivial behavior
- Methods on impls use `/** @inheritdoc */` rather than re-stating the contract

## Test plan
- [x] `npx tsc --noEmit` — 0 errors (was 5)
- [x] `npm test` — 269/269 pass
- [x] `npm run build` green