### PR TITLE
ci: add typecheck gate (build + GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,37 @@ on:
       - "feat/**"
 
 jobs:
-  test:
+  # Type check is its own job so it lights up as a separate PR status check
+  # and runs in parallel with build/test for faster overall feedback.
+  typecheck:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: "npm"
+      - run: npm ci
+      - run: npm run typecheck
 
-      - name: Install dependencies
-        run: npm ci
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
 
-      - name: Build
-        run: npm run build
-
-      - name: Test
-        run: npm test
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "wolf": "./dist/cli/index.js"
   },
   "scripts": {
-    "build": "tsup",
-    "build:dev": "WOLF_BUILD_MODE=dev tsup",
+    "typecheck": "tsc --noEmit",
+    "build": "npm run typecheck && tsup",
+    "build:dev": "npm run typecheck && WOLF_BUILD_MODE=dev tsup",
     "dev": "tsup --watch",
     "wolf": "node dist/cli/index.js",
     "test": "vitest run"

--- a/src/cli/commands/__tests__/job-list.test.ts
+++ b/src/cli/commands/__tests__/job-list.test.ts
@@ -327,12 +327,12 @@ describe('runJobListCli()', () => {
     expect(process.exitCode).toBe(1);
 
     // The user-facing message must be on stderr and must name the bad flag.
-    const errCalls = errSpy.mock.calls.map((c) => String(c[0]));
-    expect(errCalls.some((s) => s.includes('Invalid --status "nonsense"'))).toBe(true);
+    const errCalls = errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(errCalls.some((s: string) => s.includes('Invalid --status "nonsense"'))).toBe(true);
 
     // Stack frames look like `    at <fn> (...)` — the whole point of the
     // fix is that this noise must not appear anywhere in our output.
-    const allOut = [...errCalls, ...logSpy.mock.calls.map((c) => String(c[0]))].join('\n');
+    const allOut = [...errCalls, ...logSpy.mock.calls.map((c: unknown[]) => String(c[0]))].join('\n');
     expect(allOut).not.toMatch(/^\s+at\s/m);
 
     // No success row may be printed when validation fails.
@@ -353,7 +353,7 @@ describe('runJobListCli()', () => {
     expect(process.exitCode).toBe(0);
     expect(errSpy).not.toHaveBeenCalled();
     // Table output: header line + at least one data row containing the job.
-    const stdout = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    const stdout = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     expect(stdout).toMatch(/^ID\s+COMPANY\s+TITLE\s+STATUS\s+SCORE/m);
     expect(stdout).toContain('Acme');
     expect(stdout).toContain('SWE');
@@ -371,7 +371,7 @@ describe('runJobListCli()', () => {
     await runJobListCli({}, true, ctx);
 
     expect(process.exitCode).toBe(0);
-    const stdout = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    const stdout = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
     // Must parse as JSON and carry the expected shape.
     const parsed = JSON.parse(stdout);
     expect(parsed.jobs).toHaveLength(1);


### PR DESCRIPTION
## Summary
Closes the type-check blind spot that let 5 TS7006 errors live on `main` undetected for weeks.

- `package.json`: new `typecheck` script running `tsc --noEmit`; `build` and `build:dev` are now `npm run typecheck && tsup` so esbuild's transpile-only path can no longer mask type errors.
- `.github/workflows/ci.yml`: split the single `test` job into three parallel jobs (`typecheck`, `build`, `test`). Each surfaces as its own PR status check.
- Includes a small test-typing fix in `src/cli/commands/__tests__/job-list.test.ts` (overlap with PR #79) so this branch's typecheck job goes green; whichever PR merges first, the other will rebase clean.

## Test plan
- [x] `npm run build` now runs typecheck first; deliberate `const x: number = "string";` is caught and tsup never runs
- [x] `npm run build` green on this branch (after the test fix)
- [x] `npm test` 269/269 pass
- [x] CI workflow has three jobs visible on the PR