### PR TITLE
feat: typed WorkspaceNotInitializedError + visible banner on first-run

### DIFF
--- a/src/application/impl/doctorApplicationServiceImpl.ts
+++ b/src/application/impl/doctorApplicationServiceImpl.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { chromium } from 'playwright';
 import { stripComments } from '../../utils/stripComments.js';
 import { extractH2Content } from '../../utils/extractH2.js';
-import { getEnvValue } from '../../utils/instance.js';
+import { getEnvValue, currentBinaryName } from '../../utils/instance.js';
 import type { ProfileRepository } from '../../repository/profileRepository.js';
 import type {
   DoctorApplicationService,
@@ -71,7 +71,7 @@ function checkAnthropicKey(): FileCheck {
     missing: ready ? [] : ['environment variable not set'],
     hint: ready
       ? 'API key present'
-      : "run `wolf env set` or get a key at https://console.anthropic.com/",
+      : `run \`${currentBinaryName()} env set\` or get a key at https://console.anthropic.com/`,
   };
 }
 
@@ -88,7 +88,7 @@ function checkPlaywrightChromium(): FileCheck {
     missing: ready ? [] : ['binary not found'],
     hint: ready
       ? 'Chromium installed (tailor render path is ready)'
-      : 'run `npx playwright install chromium` (~150 MB), or just run `wolf tailor` once and wolf will auto-install it',
+      : `run \`npx playwright install chromium\` (~150 MB), or just run \`${currentBinaryName()} tailor\` once and wolf will auto-install it`,
   };
 }
 

--- a/src/application/impl/initApplicationServiceImpl.ts
+++ b/src/application/impl/initApplicationServiceImpl.ts
@@ -6,6 +6,7 @@ import standardQuestionsTemplate from './templates/standard_questions.md';
 import attachmentsReadmeTemplate from './templates/attachments-readme.md';
 import resumePoolTemplate from './templates/resume_pool.md';
 import { saveConfig } from '../../utils/config.js';
+import { currentBinaryName } from '../../utils/instance.js';
 import type { AppConfig } from '../../utils/types/index.js';
 import type {
   InitApplicationService,
@@ -89,8 +90,16 @@ async function ensureGitignore(workspaceDir: string): Promise<void> {
 // CLAUDE.md and AGENTS.md tell any AI assistant operating in this workspace
 // (Claude Code, OpenClaw, etc.) how the directory is laid out and what files
 // to edit. Same content; both files written so each agent finds its expected name.
+//
+// The bundled template uses `__WOLF_BIN__` placeholders for any spot that
+// names a CLI command the user (or AI agent) might run. We substitute the
+// real binary name at write time so a stable workspace's CLAUDE.md says
+// `wolf init` while a dev workspace's says `wolf-dev init`. Project-name
+// references like "wolf workspace" or "What wolf does" stay literal — they
+// describe the project, not commands to type.
 async function ensureAgentInstructions(workspaceDir: string): Promise<void> {
+  const personalized = claudeTemplate.replace(/__WOLF_BIN__/g, currentBinaryName());
   for (const filename of ['CLAUDE.md', 'AGENTS.md']) {
-    await writeIfAbsent(path.join(workspaceDir, filename), claudeTemplate);
+    await writeIfAbsent(path.join(workspaceDir, filename), personalized);
   }
 }

--- a/src/application/impl/profileApplicationServiceImpl.ts
+++ b/src/application/impl/profileApplicationServiceImpl.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { loadConfig, saveConfig, backupConfig } from '../../utils/config.js';
-import { resolveWorkspaceDir } from '../../utils/instance.js';
+import { resolveWorkspaceDir, currentBinaryName, workspaceEnvVarName } from '../../utils/instance.js';
+import { WorkspaceNotInitializedError } from '../../utils/errors/workspaceNotInitializedError.js';
 import type {
   ProfileApplicationService,
   ProfileListResult,
@@ -85,7 +86,15 @@ export class ProfileApplicationServiceImpl implements ProfileApplicationService 
 
     const srcName = opts.from ?? (await loadConfig()
       .then(c => c.default)
-      .catch(() => { throw new Error('No wolf.toml yet. Run `wolf init` first.'); }));
+      // Surface the same typed error other workspace-read sites use so the
+      // CLI banner / MCP structured response render uniformly across commands.
+      .catch(() => {
+        throw new WorkspaceNotInitializedError(
+          resolveWorkspaceDir(),
+          workspaceEnvVarName(),
+          `${currentBinaryName()} init`,
+        );
+      }));
 
     const srcDir = profileDir(srcName);
     if (!(await dirExists(srcDir))) {
@@ -131,7 +140,7 @@ export class ProfileApplicationServiceImpl implements ProfileApplicationService 
     const config = await loadConfig();
     if (name === config.default) {
       throw new Error(
-        `Cannot delete the default profile "${name}". Switch defaults first: wolf profile use <other-name>`,
+        `Cannot delete the default profile "${name}". Switch defaults first: \`${currentBinaryName()} profile use <other-name>\``,
       );
     }
 
@@ -143,7 +152,7 @@ export class ProfileApplicationServiceImpl implements ProfileApplicationService 
     if (!opts.yes) {
       throw new Error(
         `Refusing to delete ${targetDir} without --yes flag. ` +
-        `Run: wolf profile delete ${name} --yes`,
+        `Run: \`${currentBinaryName()} profile delete ${name} --yes\``,
       );
     }
 

--- a/src/application/impl/tailorApplicationServiceImpl.ts
+++ b/src/application/impl/tailorApplicationServiceImpl.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../utils/types/index.js';
 import { log } from '../../utils/logger.js';
 import { assertApiKey } from '../../utils/apiKeyGuard.js';
+import { currentBinaryName } from '../../utils/instance.js';
 import type { JobRepository } from '../../repository/jobRepository.js';
 import type { ProfileRepository } from '../../repository/profileRepository.js';
 import type { RenderService } from '../../service/renderService.js';
@@ -283,7 +284,7 @@ export class TailorApplicationServiceImpl implements TailorApplicationService {
       });
       throw new Error(
         `Tailoring brief not found at ${ctx.briefPath}. ` +
-        `Run \`wolf tailor brief --job ${ctx.job.id}\` first.`,
+        `Run \`${currentBinaryName()} tailor brief --job ${ctx.job.id}\` first.`,
       );
     }
   }

--- a/src/application/impl/templates/workspace-claude.md
+++ b/src/application/impl/templates/workspace-claude.md
@@ -5,7 +5,7 @@ This directory is a **wolf workspace** — an AI-powered job hunting environment
 
 ## First-time setup — DO THIS BEFORE ANYTHING ELSE
 
-If `wolf init` was just run, the three profile markdown files are in
+If `__WOLF_BIN__ init` was just run, the three profile markdown files are in
 **template state**: section structure is there but actual content is empty
 (or filled with `> [!IMPORTANT]` / `> [!TIP]` callouts that get stripped
 before the AI sees the file). Tailor / fill / reach will refuse to run on
@@ -93,16 +93,16 @@ wolf is a CLI tool that:
 
 | Command | Status |
 |---|---|
-| `wolf init` / `add` / `tailor` / `status` / `doctor` / `job list` / `profile` / `config` / `env` / `mcp serve` | available |
-| `wolf hunt` / `score` | NOT YET IMPLEMENTED — M2 |
-| `wolf fill` | NOT YET IMPLEMENTED — M4 |
-| `wolf reach` | NOT YET IMPLEMENTED — M5 |
+| `__WOLF_BIN__ init` / `add` / `tailor` / `status` / `doctor` / `job list` / `profile` / `config` / `env` / `mcp serve` | available |
+| `__WOLF_BIN__ hunt` / `score` | NOT YET IMPLEMENTED — M2 |
+| `__WOLF_BIN__ fill` | NOT YET IMPLEMENTED — M4 |
+| `__WOLF_BIN__ reach` | NOT YET IMPLEMENTED — M5 |
 
 **Do not suggest `hunt` / `score` / `fill` / `reach` to the user as a path to
 their goal yet** — those verbs are registered in the CLI for discoverability
 but their action handlers print "not yet available" and exit 1. If the user
 wants the underlying behaviour today, use the available substitute:
-- "find me a job" → ask the user to paste a JD or URL, then `wolf add`
+- "find me a job" → ask the user to paste a JD or URL, then `__WOLF_BIN__ add`
 - "score this job" → not yet, but tailor will still produce a tailored
   resume + cover letter without a score
 - "fill out the form" / "send the email" → not yet; offer to draft the
@@ -113,54 +113,54 @@ wants the underlying behaviour today, use the available substitute:
 ### Job lifecycle
 | Command | What it does |
 |---|---|
-| `wolf add` | Add a job manually (title, company, JD text) - returns a `jobId` |
-| `wolf hunt` | NOT YET (M2) — auto-fetch job listings from online sources |
-| `wolf score` | NOT YET (M2) — score pending jobs against the profile |
-| `wolf status` | List all tracked jobs with status and scores |
+| `__WOLF_BIN__ add` | Add a job manually (title, company, JD text) - returns a `jobId` |
+| `__WOLF_BIN__ hunt` | NOT YET (M2) — auto-fetch job listings from online sources |
+| `__WOLF_BIN__ score` | NOT YET (M2) — score pending jobs against the profile |
+| `__WOLF_BIN__ status` | List all tracked jobs with status and scores |
 
 ### Tailor pipeline (3-agent flow with checkpoints)
 | Command | What it does |
 |---|---|
-| `wolf tailor full --job <id>` | Full pipeline: analyst brief -> resume + cover letter (parallel) |
-| `wolf tailor brief --job <id>` | Step 1 only: produce the tailoring brief |
-| `wolf tailor resume --job <id>` | Step 2a only: write resume (requires existing brief) |
-| `wolf tailor cover --job <id>` | Step 2b only: write cover letter (requires existing brief) |
+| `__WOLF_BIN__ tailor full --job <id>` | Full pipeline: analyst brief -> resume + cover letter (parallel) |
+| `__WOLF_BIN__ tailor brief --job <id>` | Step 1 only: produce the tailoring brief |
+| `__WOLF_BIN__ tailor resume --job <id>` | Step 2a only: write resume (requires existing brief) |
+| `__WOLF_BIN__ tailor cover --job <id>` | Step 2b only: write cover letter (requires existing brief) |
 
 All tailor commands accept `--hint "<text>"` to give the analyst pre-analysis guidance.
 
 ### Apply & reach out
 | Command | What it does |
 |---|---|
-| `wolf fill --job <id>` | NOT YET (M4) — auto-fill a job application form |
-| `wolf reach --job <id>` | NOT YET (M5) — find hiring contacts and draft outreach emails |
+| `__WOLF_BIN__ fill --job <id>` | NOT YET (M4) — auto-fill a job application form |
+| `__WOLF_BIN__ reach --job <id>` | NOT YET (M5) — find hiring contacts and draft outreach emails |
 
 ### Config & profile management
 | Command | What it does |
 |---|---|
-| `wolf config get/set <key> [value]` | Read or edit `wolf.toml` fields by dot-path (e.g. `tailor.model`) |
-| `wolf profile list` | List all profile directories (default marked with `*`) |
-| `wolf profile create <name> [--from <src>]` | Create a new profile (clones default unless --from given) |
-| `wolf profile use <name>` | Switch the default profile (updates `wolf.toml.default`) |
-| `wolf profile delete <name> --yes` | Delete a profile directory |
-| `wolf env show / set / clear` | Manage `WOLF_*` API keys in shell |
+| `__WOLF_BIN__ config get/set <key> [value]` | Read or edit `wolf.toml` fields by dot-path (e.g. `tailor.model`) |
+| `__WOLF_BIN__ profile list` | List all profile directories (default marked with `*`) |
+| `__WOLF_BIN__ profile create <name> [--from <src>]` | Create a new profile (clones default unless --from given) |
+| `__WOLF_BIN__ profile use <name>` | Switch the default profile (updates `wolf.toml.default`) |
+| `__WOLF_BIN__ profile delete <name> --yes` | Delete a profile directory |
+| `__WOLF_BIN__ env show / set / clear` | Manage `WOLF_*` API keys in shell |
 
 > Profile data lives in `profiles/<name>/profile.md` and `standard_questions.md`.
-> Edit those files directly with any text editor — there is no `wolf profile get/set` CLI.
+> Edit those files directly with any text editor — there is no `__WOLF_BIN__ profile get/set` CLI.
 
 ## Typical workflow
 
 ### One-shot (trust the AI)
 ```
-wolf add --title "SWE" --company "Acme" --jd-text "..."   # returns jobId
-wolf tailor full --job <jobId>                            # full 3-agent pipeline
+__WOLF_BIN__ add --title "SWE" --company "Acme" --jd-text "..."   # returns jobId
+__WOLF_BIN__ tailor full --job <jobId>                            # full 3-agent pipeline
 ```
 
 ### Iterative (human-in-the-loop)
 ```
-wolf tailor brief --job <jobId> --hint "focus on ML ops"  # steer the analyst
+__WOLF_BIN__ tailor brief --job <jobId> --hint "focus on ML ops"  # steer the analyst
 # inspect and optionally edit data/jobs/<...>/src/tailoring-brief.md
-wolf tailor resume --job <jobId>                          # write resume using the brief
-wolf tailor cover --job <jobId>                           # write cover letter using the brief
+__WOLF_BIN__ tailor resume --job <jobId>                          # write resume using the brief
+__WOLF_BIN__ tailor cover --job <jobId>                           # write cover letter using the brief
 # not happy? edit brief and re-run resume/cover; no need to re-analyze
 ```
 
@@ -192,8 +192,8 @@ structured fields (id, title, score, status, etc.) that need indexing.
 
 **All `.md` and `.html` files under `src/` are editable checkpoints.** If the
 resume is off but the cover letter is fine, edit `tailoring-brief.md` (or
-`resume.html` directly) and re-run just `wolf tailor resume`. The analyst does
-not re-run unless you call `wolf tailor brief` again.
+`resume.html` directly) and re-run just `__WOLF_BIN__ tailor resume`. The analyst does
+not re-run unless you call `__WOLF_BIN__ tailor brief` again.
 
 ### hint.md / info.md convention
 
@@ -224,7 +224,7 @@ default = "default"   # the profile folder name under profiles/
 [hunt]
 minScore = 0.5                  # 0.0-1.0 - jobs below this are filtered
 maxResults = 50                 # max jobs fetched per hunt run
-# no model - wolf hunt does not call AI
+# no model - __WOLF_BIN__ hunt does not call AI
 
 [tailor]
 model = "anthropic/claude-sonnet-4-6"
@@ -283,18 +283,18 @@ skills, and education. wolf selects the most relevant content per job.
 
 **`attachments/`** — files referenced by `standard_questions.md`. Files must
 live directly in this folder; subdirectories or absolute paths are rejected.
-If a file referenced in `standard_questions.md` is missing, `wolf fill` pauses
+If a file referenced in `standard_questions.md` is missing, `__WOLF_BIN__ fill` pauses
 and asks you to drop it in.
 
 ## API keys
 
 Stored as shell environment variables, not in files here.
-Run `wolf env show` to see which keys are configured.
-Run `wolf env set` to add missing keys.
+Run `__WOLF_BIN__ env show` to see which keys are configured.
+Run `__WOLF_BIN__ env set` to add missing keys.
 
 | Key | Required for |
 |---|---|
 | `WOLF_ANTHROPIC_API_KEY` | All AI features (tailor, score, reach) |
-| `WOLF_APIFY_API_TOKEN` | `wolf hunt` |
-| `WOLF_GMAIL_CLIENT_ID` | `wolf reach` (sending email) |
-| `WOLF_GMAIL_CLIENT_SECRET` | `wolf reach` (sending email) |
+| `WOLF_APIFY_API_TOKEN` | `__WOLF_BIN__ hunt` |
+| `WOLF_GMAIL_CLIENT_ID` | `__WOLF_BIN__ reach` (sending email) |
+| `WOLF_GMAIL_CLIENT_SECRET` | `__WOLF_BIN__ reach` (sending email) |

--- a/src/cli/commands/__tests__/init.test.ts
+++ b/src/cli/commands/__tests__/init.test.ts
@@ -197,6 +197,36 @@ describe('init()', () => {
 
   // Dev empty init is the exact path the acceptance orchestrator will run in
   // /tmp/wolf-at-* workspaces. The dev marker makes the workspace self-labeling.
+  // Asserts the `__WOLF_BIN__` placeholder in workspace-claude.md gets
+  // substituted at write time. A typo in the placeholder regex (or a forgotten
+  // .replace() call) would silently ship the literal token to friends'
+  // workspaces — this test pins the contract so the binary name in CLAUDE.md
+  // and AGENTS.md tracks the active build.
+  it('substitutes __WOLF_BIN__ placeholder in CLAUDE.md / AGENTS.md', async () => {
+    const dir = makeTempDir();
+    await fs.mkdir(dir, { recursive: true });
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+
+    try {
+      await init({ empty: true, here: true });
+
+      for (const filename of ['CLAUDE.md', 'AGENTS.md']) {
+        const content = await fs.readFile(path.join(dir, filename), 'utf-8');
+        // Placeholder must be fully resolved — never escape into user files.
+        expect(content).not.toContain('__WOLF_BIN__');
+        // The actual binary name (`wolf` for stable, `wolf-dev` for dev)
+        // must appear at least where the substitution happened. Tests run
+        // in stable mode by default (no WOLF_BUILD_MODE set), so we expect
+        // `wolf init` to materialize.
+        expect(content).toContain('wolf init');
+      }
+    } finally {
+      process.chdir(originalCwd);
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('writes instance.mode = dev for --dev --empty workspaces', async () => {
     const dir = makeTempDir();
     process.env.WOLF_BUILD_MODE = 'dev';

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,6 @@
 import type { AppContext } from '../../runtime/appContext.js';
 import { createAppContext } from '../../runtime/appContext.js';
+import { currentBinaryName } from '../../utils/instance.js';
 import type { DoctorReport } from '../../application/doctorApplicationService.js';
 
 export type { DoctorReport, FileCheck } from '../../application/doctorApplicationService.js';
@@ -35,7 +36,7 @@ export function formatDoctor(report: DoctorReport): string {
   if (!report.ready) {
     lines.push(``);
     lines.push(`Open profiles/${report.profileName}/profile.md and fill the > [!IMPORTANT]`);
-    lines.push(`sections, then re-run \`wolf doctor\`.`);
+    lines.push(`sections, then re-run \`${currentBinaryName()} doctor\`.`);
   }
   return lines.join('\n');
 }

--- a/src/cli/commands/env.ts
+++ b/src/cli/commands/env.ts
@@ -1,5 +1,6 @@
 import { confirm, input } from '@inquirer/prompts';
 import { EnvApplicationServiceImpl } from '../../application/impl/envApplicationServiceImpl.js';
+import { currentBinaryName } from '../../utils/instance.js';
 
 // env commands have no DB / repo dependencies, so we use a module-level
 // singleton rather than threading the full AppContext through. The application
@@ -116,7 +117,7 @@ ${bold('Written to')} ${rcFile}
 Restart your terminal to apply, or run:
   ${bold(`source ${rcFile}`)}
 
-Then verify with: ${bold('wolf env show')}
+Then verify with: ${bold(`${currentBinaryName()} env show`)}
 `);
 }
 
@@ -144,7 +145,7 @@ export async function envSetOne(key: string, value: string, rcFile?: string): Pr
   console.log(`\n  ${green('✓')} ${bold(key)} written to ${target}\n`);
   console.log(`Restart your terminal to apply, or run:`);
   console.log(`  ${bold(`source ${target}`)}\n`);
-  console.log(`Then verify with: ${bold('wolf env show')}\n`);
+  console.log(`Then verify with: ${bold(`${currentBinaryName()} env show`)}\n`);
 }
 
 /**

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { confirm } from '@inquirer/prompts';
 import { backupConfig } from '../../utils/config.js';
 import { envSet } from './env.js';
-import { assertDevBuildForDevFlag, getEnvValue, resolveWorkspaceDir } from '../../utils/instance.js';
+import { assertDevBuildForDevFlag, getEnvValue, resolveWorkspaceDir, currentBinaryName } from '../../utils/instance.js';
 import { InitApplicationServiceImpl } from '../../application/impl/initApplicationServiceImpl.js';
 
 // init must run in a fresh workspace where wolf.toml does not yet exist, so
@@ -92,11 +92,11 @@ ${missing.map(k => `  ${red('✗')} ${k}`).join('\n')}
 
 ${bold("If you don't need all of them:")}
   Only ${bold('WOLF_ANTHROPIC_API_KEY')} is required to get started.
-  Others can be added later via ${bold('wolf env set')}.
+  Others can be added later via ${bold(`${currentBinaryName()} env set`)}.
 
 ${bold('If you already set them but haven\'t restarted yet:')}
   Restart your terminal, or run: ${bold('source ~/.zshrc')}
-  Then verify with: ${bold('wolf env show')}
+  Then verify with: ${bold(`${currentBinaryName()} env show`)}
 `);
     const setupNow = await confirm({
       message: 'Set up missing keys now?',
@@ -121,7 +121,7 @@ Consider cd-ing to a dedicated folder first, e.g.:
       default: false,
     });
     if (!proceed) {
-      console.log('Cancelled. cd to your preferred directory and run wolf init again.');
+      console.log(`Cancelled. cd to your preferred directory and run ${currentBinaryName()} init again.`);
       return;
     }
   }

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -1,4 +1,5 @@
 import { createAppContext, type AppContext } from '../../runtime/appContext.js';
+import { currentBinaryName } from '../../utils/instance.js';
 
 /**
  * Lists every profile directory under profiles/, marking the default with `*`.
@@ -6,11 +7,11 @@ import { createAppContext, type AppContext } from '../../runtime/appContext.js';
 export async function profileList(ctx: AppContext = createAppContext()): Promise<void> {
   const result = await ctx.profileApp.list();
   if (result.kind === 'no-profiles-dir') {
-    console.log('No profiles directory. Run `wolf init` first.');
+    console.log(`No profiles directory. Run \`${currentBinaryName()} init\` first.`);
     return;
   }
   if (result.kind === 'empty') {
-    console.log('No profiles. Run `wolf init` or `wolf profile create <name>`.');
+    console.log(`No profiles. Run \`${currentBinaryName()} init\` or \`${currentBinaryName()} profile create <name>\`.`);
     return;
   }
   for (const { name, isDefault } of result.profiles) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,7 +15,7 @@ import { configGet, configSet } from './commands/config.js';
 import { profileList, profileCreate, profileUse, profileDelete } from './commands/profile.js';
 import { startMcpServer } from '../mcp/server.js';
 import { DEV_WARNING, isDevBuild } from '../utils/instance.js';
-import { MissingApiKeyError, MissingChromiumError } from '../utils/errors/index.js';
+import { MissingApiKeyError, MissingChromiumError, WorkspaceNotInitializedError } from '../utils/errors/index.js';
 import { statusTag, notYetMessage } from '../utils/commandStatus.js';
 
 const program = new Command();
@@ -52,6 +52,20 @@ function renderError(err: unknown): void {
   }
   if (err instanceof MissingChromiumError) {
     process.stderr.write(`wolf: ${err.message}\n`);
+    process.exit(1);
+  }
+  if (err instanceof WorkspaceNotInitializedError) {
+    // Use a top + bottom banner so a non-technical user can immediately see
+    // this is a "you need to do something" message, not a wolf crash.
+    const bar = '='.repeat(64);
+    process.stderr.write(
+      `\n${bar}\n` +
+      `  wolf: workspace not initialized\n\n` +
+      `  Path checked:  ${err.workspacePath}\n` +
+      `  Init command:  ${err.initCommand}\n\n` +
+      `  Set ${err.envVarName} to use a different directory.\n` +
+      `${bar}\n\n`,
+    );
     process.exit(1);
   }
   // Unknown — let Node's default handler print the stack and exit non-zero.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,7 @@ import { envShow, envSet, envSetOne, envClear } from './commands/env.js';
 import { configGet, configSet } from './commands/config.js';
 import { profileList, profileCreate, profileUse, profileDelete } from './commands/profile.js';
 import { startMcpServer } from '../mcp/server.js';
-import { DEV_WARNING, isDevBuild } from '../utils/instance.js';
+import { DEV_WARNING, isDevBuild, currentBinaryName } from '../utils/instance.js';
 import { MissingApiKeyError, MissingChromiumError, WorkspaceNotInitializedError } from '../utils/errors/index.js';
 import { statusTag, notYetMessage } from '../utils/commandStatus.js';
 
@@ -72,8 +72,11 @@ function renderError(err: unknown): void {
   throw err;
 }
 
+// Bin name reflects which binary the user actually invoked (`wolf` for stable,
+// `wolf-dev` for dev builds), so `--help` and subcommand `--help` echo back
+// the exact command they typed.
 program
-  .name('wolf')
+  .name(currentBinaryName())
   .description('Workflow of Outreaching, LinkedIn & Filling — AI-powered job hunting CLI')
   .version('0.1.0');
 
@@ -166,7 +169,7 @@ tailorCmd
   });
 tailorCmd
   .command('resume')
-  .description('Step 2a: write resume HTML + PDF using the existing brief (requires `wolf tailor brief` first)')
+  .description(`Step 2a: write resume HTML + PDF using the existing brief (requires \`${currentBinaryName()} tailor brief\` first)`)
   .requiredOption('-j, --job <id>', 'Job ID')
   .option('-p, --profile <id>', 'Profile to use')
   .action(async (opts) => {
@@ -175,7 +178,7 @@ tailorCmd
   });
 tailorCmd
   .command('cover')
-  .description('Step 2b: write cover letter HTML + PDF using the existing brief (requires `wolf tailor brief` first)')
+  .description(`Step 2b: write cover letter HTML + PDF using the existing brief (requires \`${currentBinaryName()} tailor brief\` first)`)
   .requiredOption('-j, --job <id>', 'Job ID')
   .option('-p, --profile <id>', 'Profile to use')
   .action(async (opts) => {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { add } from '../cli/commands/add.js';
 import { tailor } from '../cli/commands/tailor.js';
 import { DEV_WARNING, getEnvValue, isDevBuild } from '../utils/instance.js';
-import { MissingApiKeyError, MissingChromiumError } from '../utils/errors/index.js';
+import { MissingApiKeyError, MissingChromiumError, WorkspaceNotInitializedError } from '../utils/errors/index.js';
 
 type ToolBaseName = 'hunt' | 'add' | 'score' | 'tailor' | 'fill' | 'reach' | 'status';
 
@@ -57,6 +57,25 @@ function errorResponse(
             withMcpWarning({
               errorCode: err.code,
               installCommand: err.installCommand,
+              message: err.message,
+            }),
+          ),
+        },
+      ],
+      isError: true,
+    };
+  }
+  if (err instanceof WorkspaceNotInitializedError) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            withMcpWarning({
+              errorCode: err.code,
+              workspacePath: err.workspacePath,
+              envVarName: err.envVarName,
+              initCommand: err.initCommand,
               message: err.message,
             }),
           ),
@@ -124,14 +143,23 @@ then present the result to the user and offer to run wolf_tailor.`,
       if (!args.title || !args.company || !args.jdText) {
         return jsonContent(missingParam('title/company/jdText', 'Extract title, company, and jdText from the user\'s input before calling wolf_add.'));
       }
-      const result = await add({
-        title: args.title as string,
-        company: args.company as string,
-        jdText: args.jdText as string,
-        url: args.url as string | undefined,
-        profileId: args.profileId as string | undefined,
-      });
-      return jsonContent(result);
+      try {
+        const result = await add({
+          title: args.title as string,
+          company: args.company as string,
+          jdText: args.jdText as string,
+          url: args.url as string | undefined,
+          profileId: args.profileId as string | undefined,
+        });
+        return jsonContent(result);
+      } catch (err) {
+        // wolf_add reads `wolf.toml` + the profile, so a missing workspace
+        // surfaces here as `WorkspaceNotInitializedError`. Map all our typed
+        // errors so the AI orchestrator can guide the user.
+        const mapped = errorResponse(err);
+        if (mapped) return mapped;
+        throw err;
+      }
     }
   );
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -2,7 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { add } from '../cli/commands/add.js';
 import { tailor } from '../cli/commands/tailor.js';
-import { DEV_WARNING, getEnvValue, isDevBuild } from '../utils/instance.js';
+import { DEV_WARNING, getEnvValue, isDevBuild, currentBinaryName } from '../utils/instance.js';
 import { MissingApiKeyError, MissingChromiumError, WorkspaceNotInitializedError } from '../utils/errors/index.js';
 
 type ToolBaseName = 'hunt' | 'add' | 'score' | 'tailor' | 'fill' | 'reach' | 'status';
@@ -299,10 +299,10 @@ Returns what's missing and what the next step should be.`,
             apify: !!getEnvValue('APIFY_API_TOKEN'),
           },
           next_step: !hasProfile
-            ? 'Run `wolf init` in your workspace to set up your profile.'
+            ? `Run \`${currentBinaryName()} init\` in your workspace to set up your profile.`
             : !getEnvValue('ANTHROPIC_API_KEY')
               ? 'Set WOLF_ANTHROPIC_API_KEY in your shell to enable AI features.'
-              : 'Wolf is ready. Try `wolf_add` or `wolf_hunt` to get started.',
+              : `Wolf is ready. Try \`${mcpToolName('add')}\` or \`${mcpToolName('hunt')}\` to get started.`,
         };
 
         return jsonContent(result);
@@ -310,7 +310,7 @@ Returns what's missing and what the next step should be.`,
         return jsonContent({
           profile: 'missing',
           integrations: { anthropic: false, apify: false },
-          next_step: 'No wolf.toml found. Run `wolf init` in your workspace directory first.',
+          next_step: `No wolf.toml found. Run \`${currentBinaryName()} init\` in your workspace directory first.`,
         });
       }
     }

--- a/src/repository/impl/fileProfileRepositoryImpl.ts
+++ b/src/repository/impl/fileProfileRepositoryImpl.ts
@@ -56,13 +56,13 @@ export class FileProfileRepositoryImpl implements ProfileRepository {
     const config = AppConfigSchema.parse(parse(raw));
     const defaultName = config.default;
     if (!defaultName) {
-      throw new Error('wolf.toml is missing the `default` field. Run wolf init to repair your config.');
+      throw new Error(`wolf.toml is missing the \`default\` field. Run \`${currentBinaryName()} init\` to repair your config.`);
     }
     if (!(await this.dirExists(defaultName))) {
       throw new Error(
         `Default profile directory 'profiles/${defaultName}/' not found. ` +
         `Either rename a profile folder back to '${defaultName}', or run ` +
-        `\`wolf profile use <name>\` to point wolf.toml at an existing profile.`,
+        `\`${currentBinaryName()} profile use <name>\` to point wolf.toml at an existing profile.`,
       );
     }
     const md = await this.getProfileMd(defaultName);
@@ -93,7 +93,7 @@ export class FileProfileRepositoryImpl implements ProfileRepository {
       return await fs.readFile(mdPath, 'utf-8');
     } catch {
       throw new Error(
-        `profile.md for profile '${name}' not found. Expected profiles/${name}/profile.md to exist. Run wolf init to create it.`,
+        `profile.md for profile '${name}' not found. Expected profiles/${name}/profile.md to exist. Run \`${currentBinaryName()} init\` to create it.`,
       );
     }
   }
@@ -104,7 +104,7 @@ export class FileProfileRepositoryImpl implements ProfileRepository {
       return await fs.readFile(mdPath, 'utf-8');
     } catch {
       throw new Error(
-        `Resume pool for profile '${name}' not found. Expected profiles/${name}/resume_pool.md to exist. Run wolf init to create it.`,
+        `Resume pool for profile '${name}' not found. Expected profiles/${name}/resume_pool.md to exist. Run \`${currentBinaryName()} init\` to create it.`,
       );
     }
   }
@@ -115,7 +115,7 @@ export class FileProfileRepositoryImpl implements ProfileRepository {
       return await fs.readFile(mdPath, 'utf-8');
     } catch {
       throw new Error(
-        `standard_questions.md for profile '${name}' not found. Expected profiles/${name}/standard_questions.md to exist. Run wolf init to create it.`,
+        `standard_questions.md for profile '${name}' not found. Expected profiles/${name}/standard_questions.md to exist. Run \`${currentBinaryName()} init\` to create it.`,
       );
     }
   }

--- a/src/repository/impl/fileProfileRepositoryImpl.ts
+++ b/src/repository/impl/fileProfileRepositoryImpl.ts
@@ -4,6 +4,8 @@ import { parse } from 'smol-toml';
 import type { ProfileRepository } from '../profileRepository.js';
 import type { Profile } from '../../utils/types/index.js';
 import { AppConfigSchema } from '../../utils/schemas.js';
+import { WorkspaceNotInitializedError } from '../../utils/errors/workspaceNotInitializedError.js';
+import { workspaceEnvVarName, currentBinaryName } from '../../utils/instance.js';
 
 /**
  * Reads profiles from `<workspace>/profiles/<name>/`. Each profile is a folder
@@ -43,7 +45,13 @@ export class FileProfileRepositoryImpl implements ProfileRepository {
     try {
       raw = await fs.readFile(configPath, 'utf-8');
     } catch {
-      throw new Error('wolf.toml not found. Run wolf init to set up your workspace.');
+      // Same typed error surfaced from `loadConfig` so both entry points
+      // produce the same structured "workspace not initialized" signal.
+      throw new WorkspaceNotInitializedError(
+        this.workspaceDir,
+        workspaceEnvVarName(),
+        `${currentBinaryName()} init`,
+      );
     }
     const config = AppConfigSchema.parse(parse(raw));
     const defaultName = config.default;

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -45,10 +45,16 @@ describe('config utils', () => {
       expect(loaded.tailor.defaultCoverLetterTone).toBe('professional');
     });
 
-    it('throws if wolf.toml does not exist', async () => {
+    // Asserts the typed-error contract: a missing wolf.toml yields a
+    // `WorkspaceNotInitializedError` whose fields drive the CLI banner +
+    // MCP structured response. Catching as `Error` and inspecting `.code`
+    // avoids importing the class (and its sibling `instance.ts` deps) in
+    // tests that don't need them.
+    it('throws WorkspaceNotInitializedError if wolf.toml does not exist', async () => {
       const { loadConfig } = await import('../config.js');
+      const { WorkspaceNotInitializedError } = await import('../errors/workspaceNotInitializedError.js');
       await fs.rm(path.join(tmpDir, 'wolf.toml'), { force: true });
-      await expect(loadConfig()).rejects.toThrow('wolf.toml not found');
+      await expect(loadConfig()).rejects.toBeInstanceOf(WorkspaceNotInitializedError);
     });
   });
 

--- a/src/utils/apiKeyGuard.ts
+++ b/src/utils/apiKeyGuard.ts
@@ -1,4 +1,4 @@
-import { getEnvValue } from './instance.js';
+import { getEnvValue, currentBinaryName } from './instance.js';
 import { MissingApiKeyError } from './errors/missingApiKeyError.js';
 
 /**
@@ -26,5 +26,7 @@ export function assertApiKey(name: keyof typeof KEY_HINTS | string): void {
   if (value && value.length > 0) return;
 
   const hintUrl = KEY_HINTS[name] ?? '';
-  throw new MissingApiKeyError(`WOLF_${name}`, hintUrl);
+  // setCommand reflects the binary the user actually ran (`wolf` for stable,
+  // `wolf-dev` for dev) so the error banner suggests a command they can copy.
+  throw new MissingApiKeyError(`WOLF_${name}`, hintUrl, `${currentBinaryName()} env set`);
 }

--- a/src/utils/commandStatus.ts
+++ b/src/utils/commandStatus.ts
@@ -1,3 +1,5 @@
+import { currentBinaryName } from './instance.js';
+
 /**
  * Single source of truth for which CLI commands are implemented vs. still
  * scheduled for a future milestone. Consumed by:
@@ -51,5 +53,5 @@ export function statusTag(name: CommandName): string {
 export function notYetMessage(name: CommandName): string {
   const s = COMMAND_STATUS[name];
   if (s.available) throw new Error(`notYetMessage called for available command: ${name}`);
-  return `wolf ${name}: not yet available in this release (${s.milestone}). See https://github.com/guanyu-gerry-tao/wolf/blob/main/docs/overview/MILESTONES.md for the roadmap.`;
+  return `${currentBinaryName()} ${name}: not yet available in this release (${s.milestone}). See https://github.com/guanyu-gerry-tao/wolf/blob/main/docs/overview/MILESTONES.md for the roadmap.`;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,7 +4,8 @@ import path from 'node:path';
 import { parse, stringify } from 'smol-toml';
 import type { AppConfig } from './types/index.js';
 import { AppConfigSchema } from './schemas.js';
-import { resolveWorkspaceDir } from './instance.js';
+import { resolveWorkspaceDir, workspaceEnvVarName, currentBinaryName } from './instance.js';
+import { WorkspaceNotInitializedError } from './errors/workspaceNotInitializedError.js';
 
 /** Returns the path to wolf.toml in the resolved stable/dev workspace. */
 const configPath = (workspaceDir = resolveWorkspaceDir()) => path.join(workspaceDir, 'wolf.toml');
@@ -34,7 +35,8 @@ export function loadConfigSync(): AppConfig {
 /**
  * Loads the user config from `wolf.toml` in the current working directory.
  *
- * @throws If `wolf.toml` does not exist — run `wolf init` first.
+ * @throws {WorkspaceNotInitializedError} If `wolf.toml` does not exist —
+ *   the user has never run `wolf init` for this workspace.
  * @throws If the file cannot be parsed.
  */
 export async function loadConfig(): Promise<AppConfig> {
@@ -42,7 +44,13 @@ export async function loadConfig(): Promise<AppConfig> {
   try {
     raw = await fs.readFile(configPath(), 'utf-8');
   } catch {
-    throw new Error('wolf.toml not found. Run wolf init to set up your workspace.');
+    // Surface the typed error so the CLI top-level catch can render a clean
+    // banner and the MCP layer can return a structured errorCode.
+    throw new WorkspaceNotInitializedError(
+      resolveWorkspaceDir(),
+      workspaceEnvVarName(),
+      `${currentBinaryName()} init`,
+    );
   }
   const parsed = parse(raw);
   return AppConfigSchema.parse(parsed);

--- a/src/utils/errors/index.ts
+++ b/src/utils/errors/index.ts
@@ -4,3 +4,4 @@
  */
 export { MissingApiKeyError } from './missingApiKeyError.js';
 export { MissingChromiumError } from './missingChromiumError.js';
+export { WorkspaceNotInitializedError } from './workspaceNotInitializedError.js';

--- a/src/utils/errors/workspaceNotInitializedError.ts
+++ b/src/utils/errors/workspaceNotInitializedError.ts
@@ -1,0 +1,28 @@
+/**
+ * Thrown when wolf tries to read a workspace (`wolf.toml` etc.) but the
+ * workspace directory has never been initialized at the expected path.
+ *
+ * Carries enough context for the CLI top-level catch to render a clear
+ * `=== wolf: workspace not initialized ===` banner that even a non-technical
+ * user can act on, and for MCP tool handlers to serialize a structured
+ * `errorCode: WORKSPACE_NOT_INITIALIZED` response.
+ */
+export class WorkspaceNotInitializedError extends Error {
+  readonly code = 'WORKSPACE_NOT_INITIALIZED' as const;
+
+  constructor(
+    /** Absolute path wolf tried to read from (e.g. `/Users/x/wolf`). */
+    readonly workspacePath: string,
+    /** Env var users can set to point wolf at a different path. */
+    readonly envVarName: string,
+    /** Init command appropriate for the current binary (stable vs. dev). */
+    readonly initCommand: string,
+  ) {
+    super(
+      `wolf workspace not initialized at ${workspacePath}. ` +
+        `Run '${initCommand}' to set one up. ` +
+        `(Set ${envVarName} to use a different directory.)`,
+    );
+    this.name = 'WorkspaceNotInitializedError';
+  }
+}

--- a/src/utils/instance.ts
+++ b/src/utils/instance.ts
@@ -41,3 +41,20 @@ export function assertDevBuildForDevFlag(): void {
     throw new Error('--dev requires a dev build; run `npm run build:dev` then retry from the clone.');
   }
 }
+
+/**
+ * Bin name the user just typed — `wolf` for stable, `wolf-dev` for dev.
+ * Used in user-facing error messages so the suggested fix command matches
+ * whichever binary they're actually running.
+ */
+export function currentBinaryName(): string {
+  return isDevBuild() ? 'wolf-dev' : 'wolf';
+}
+
+/**
+ * Env var that overrides the workspace directory for the current build.
+ * `WOLF_DEV_HOME` for dev builds, `WOLF_HOME` for stable.
+ */
+export function workspaceEnvVarName(): string {
+  return isDevBuild() ? 'WOLF_DEV_HOME' : 'WOLF_HOME';
+}


### PR DESCRIPTION
## Summary
Two related improvements to first-run UX, expanded scope from initial PR:

1. **Workspace-not-initialized banner** — when wolf runs without an initialized workspace, render a clean `=== ... ===` banner instead of dumping a Node stack trace.
2. **Dynamic binary name in user-facing strings** — every place wolf prints a "run X" suggestion or echoes its own name now matches the binary the user actually invoked (`wolf` for stable, `wolf-dev` for dev), so the two never drift.

## Why this matters now
wolf 0.1 ships to friends who'll likely run `wolf doctor` or `wolf add` before remembering `wolf init`. Two prior bugs:
- The current behaviour dumped a Node default unhandled-rejection stack trace — scary for non-technical users, with the actual fix instruction buried inside.
- Every "Run wolf init" hint hardcoded `wolf`, so dev-build users running `wolf-dev` saw advice that wouldn't work for them on copy/paste.

## Banner — before / after

**Before:**
```
file:///.../dist/cli/index.js:789
  throw err;
  ^
Error: wolf.toml not found. Run wolf init to set up your workspace.
    at FileProfileRepositoryImpl.getDefault (...)
    at async DoctorApplicationServiceImpl.run (...)
```

**After:**
```
================================================================
  wolf: workspace not initialized

  Path checked:  /Users/x/wolf-dev
  Init command:  wolf-dev init

  Set WOLF_DEV_HOME to use a different directory.
================================================================
```

## Changes — typed error
- New typed error [`WorkspaceNotInitializedError`](src/utils/errors/workspaceNotInitializedError.ts) (`code: WORKSPACE_NOT_INITIALIZED`). Same pattern as PR1's `MissingApiKeyError` / `MissingChromiumError`. Carries `workspacePath`, `envVarName`, `initCommand`.
- Helpers `currentBinaryName()` and `workspaceEnvVarName()` in [src/utils/instance.ts](src/utils/instance.ts) so messages match the binary the user actually ran.
- Two throw sites swap raw `Error` for the typed one ([`utils/config.ts`](src/utils/config.ts), [`fileProfileRepositoryImpl.ts`](src/repository/impl/fileProfileRepositoryImpl.ts)).
- [`cli/index.ts`](src/cli/index.ts) `renderError()` adds a third `instanceof` branch — banner + `exit 1`.
- [`mcp/tools.ts`](src/mcp/tools.ts) `errorResponse()` serializes structured `{ errorCode, workspacePath, envVarName, initCommand, message }`. The `add` handler also wrapped (was missing the wrap that `tailor` already had).
- Test updated: [`utils/__tests__/config.test.ts`](src/utils/__tests__/config.test.ts) asserts `instanceof WorkspaceNotInitializedError`.

## Changes — dynamic binary name sweep
Each site below was reviewed individually — only kept if it's a "command to copy/run" or AI-readable suggestion. Project-name references (`wolf workspace`, `What wolf does`), file names (`wolf.toml`), and headings (`wolf doctor — profile readiness check`) deliberately stay literal.

| Layer | File | Sites |
|---|---|---|
| CLI surface | `cli/index.ts` | `program.name(currentBinaryName())`; tailor resume/cover descriptions |
| Console prompts | `cli/commands/init.ts`, `env.ts`, `profile.ts`, `doctor.ts` | onboarding, post-set, empty-profile, re-run hints |
| Repo error msgs | `fileProfileRepositoryImpl.ts` | 4 `Run wolf init` references in error throws |
| Typed errors | `utils/apiKeyGuard.ts` | `MissingApiKeyError.setCommand` now `${binName} env set` |
| Stub commands | `utils/commandStatus.ts` | `notYetMessage` → `wolf-dev hunt: not yet available...` |
| MCP | `mcp/tools.ts` | `status` tool's `next_step` strings |
| Workspace template (AI-read) | `application/impl/templates/workspace-claude.md` | 37 `wolf <verb>` → `__WOLF_BIN__ <verb>`, substituted at write time by `initApplicationServiceImpl.ensureAgentInstructions` |

## Test plan
- [x] `npm run typecheck` green
- [x] `npm run build:dev` green
- [x] 269 unit tests pass (one updated assertion in config.test.ts)
- [x] `wolf-dev --help` shows `Usage: wolf-dev`
- [x] `wolf-dev hunt` → `wolf-dev hunt: not yet available...`
- [x] `WOLF_DEV_HOME=/tmp/non-existent wolf-dev doctor` shows the banner with `Init command: wolf-dev init` and `Set WOLF_DEV_HOME...`
- [ ] Reviewer: spot-check the workspace template — `__WOLF_BIN__` should appear ONLY before real CLI verbs, never in descriptive text like "wolf workspace"
- [ ] Reviewer: confirm no other `throw new Error('wolf.toml not found...')` was missed